### PR TITLE
ImageController.php: Extend ImageController to try various file extensions

### DIFF
--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -12,14 +12,35 @@ class ImageController extends Controller
         $this->middleware('auth');
     }
 
-    
+    private function getImage($basePath, $name, $defaultImagePath)
+    {
+        $extensions = ['svg', 'jpg', 'png'];
+
+        foreach ($extensions as $extension) {
+            $path = $basePath . $name . '.' . $extension;
+
+            if (Storage::exists($path)) {
+                return Storage::get($path);
+            }
+        }
+
+        // If none of the specified extensions exist, return the content of the default image
+        return Storage::get($defaultImagePath);
+    }
+
     public function getFlagImage($name)
     {
-        return Storage::get('/images/flags/' . $name . '.png');
+        $basePath = '/images/flags/';
+        $defaultImagePath = '/images/flags/default-flag.svg';
+
+        return $this->getImage($basePath, $name, $defaultImagePath);
     }
 
     public function getBookImage($name)
     {
-        return Storage::get('/images/book_images/' . $name);
+        $basePath = '/images/book_images/';
+        $defaultImagePath = '/images/book_images/default.jpg';
+
+        return $this->getImage($basePath, $name, $defaultImagePath);
     }
 }

--- a/storage/app/images/flags/default-flag.svg
+++ b/storage/app/images/flags/default-flag.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="427">
+<rect width="640" height="427" fill="#FFFFFF"/>
+</svg>


### PR DESCRIPTION
and upon failure default to a standard image.

There are various ways to implement this, including separately defining `$extensions` in each function for image types unique to flags or books and passing that as a function parameter to `getImage(...)`.