### PR TITLE
Improved German support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,7 @@
 *.scss linguist-vendored
 *.js linguist-vendored
 CHANGELOG.md export-ignore
+
+# make sure executables have the right line endings
+*.sh text eol=lf
+./tools/django_server/manage.py text eol=lf

--- a/app/Models/TextBlock.php
+++ b/app/Models/TextBlock.php
@@ -238,6 +238,24 @@ class TextBlock
                 }
             }
 
+            // german post processing
+            if ($this->language == 'german') { 
+                // nouns' lemma needs der/die/das before them
+                if ($this->tokenizedWords[$wordIndex]->pos == 'NOUN' && $this->tokenizedWords[$wordIndex]->l !== '') {
+                    if (count($this->tokenizedWords[$wordIndex]->g) && $this->tokenizedWords[$wordIndex]->g[0] =='Fem') {
+                        $word->lemma = 'die ' . $word->lemma;
+                    }
+
+                    if (count($this->tokenizedWords[$wordIndex]->g) && $this->tokenizedWords[$wordIndex]->g[0] == 'Masc') {
+                        $word->lemma = 'der ' . $word->lemma;
+                    }
+
+                    if (count($this->tokenizedWords[$wordIndex]->g) && $this->tokenizedWords[$wordIndex]->g[0] == 'Neut') {
+                        $word->lemma = 'das ' . $word->lemma;
+                    }
+                    
+                }
+            }
             $this->processedWords[$processedWordCount] = $word;
             $processedWordCount ++;
         }

--- a/tools/django_server/tokenizer/views.py
+++ b/tools/django_server/tokenizer/views.py
@@ -29,7 +29,7 @@ hiraganaConverter = pykakasi.kakasi()
 norwegian_nlp = spacy.load("nb_core_news_sm", disable = ['ner', 'parser'])
 norwegian_nlp.add_pipe("custom_sentence_splitter", first=True)
 
-german_nlp = spacy.load("de_core_news_sm", disable = ['ner', 'parser'])
+german_nlp = spacy.load("de_core_news_sm", disable = ['ner'])
 german_nlp.add_pipe("custom_sentence_splitter", first=True)
 
 korean_nlp = spacy.load("ko_core_news_sm", disable = ['ner', 'parser'])
@@ -215,11 +215,23 @@ def tokenizeText(words, language):
                     lemmaReading.append(x['hira'])
 
             gender = ''
-            if language == 'norwegian':
+            if language in ('norwegian', 'german'):
                 gender = token.morph.get("Gender")
 
-            tokenizedWords.append({'w': word, 'r': ''.join(reading), 'l': token.lemma_, 'lr': ''.join(lemmaReading), 'pos': token.pos_,'si': sentenceIndex, 'g': gender})
+            lemma = token.lemma_
+            if language == 'german' and token.pos_ == 'VERB':
+                lemma = get_separable_lemma(token)
+            
+            tokenizedWords.append({'w': word, 'r': ''.join(reading), 'l': lemma, 'lr': ''.join(lemmaReading), 'pos': token.pos_,'si': sentenceIndex, 'g': gender})
+    print(tokenizedWords)
     return tokenizedWords
+
+# used for german separable verbs
+def get_separable_lemma(token):
+    prefix = [c.text for c in token.children if c.dep_ == 'svp']
+    if len(prefix) > 0:
+        return prefix[0] + token.lemma_
+    return token.lemma_
 
 # loads n .epub file
 def loadBook(file):


### PR DESCRIPTION
This PR is a quick attempt at improving the support for German. There were two main issues that I wanted to try to address:

1. Noun Gender

Like many other languages, [German has the concept of grammatical gender for nouns](https://en.wikipedia.org/wiki/Grammatical_gender_in_German). When learning, it is useful to have the definite article along with the actual noun, since it can be difficult to determine the gender without it. This adds the definite article to the lemma (similar to what is already happening with Norwegian).

2. Separable Verbs

German also has the quirk of [separable verbs](https://en.wikipedia.org/wiki/Separable_verb). This means that sometimes the prefix/particle and the base verb do not appear together. The change here makes it so that sentences like 

```
Ich greife den Feind an.
Ich habe den Feind angegriffen.
```

both have `angreifen` as the verb lemma. This does create a bit of weirdness in the UI, because it does not identify `greife` and `an` as being part of the same word. Rather, it just shows `angreifen` as the base word when highlighting `greife`. It might also create some weirdness if people upgrade their instances in place.