### PR TITLE
Dockerfile refactor

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,0 @@
-/docker/mysql/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 name: linguacafe
 
 networks:
@@ -27,15 +27,15 @@ services:
         restart: unless-stopped
         tty: true
         ports:
-          - "3308:3306"
+            - "3308:3306"
         volumes:
-          - /your/linguacafe/database/folder:/var/lib/mysql
+            - /your/linguacafe/database/folder:/var/lib/mysql
         environment:
-          MYSQL_DATABASE: linguacafe
-          MYSQL_USER: linguacafe
-          MYSQL_PASSWORD: linguacafe
-          MYSQL_ROOT_PASSWORD: linguacafe
-          SERVICE_NAME: linguacafe
+            MYSQL_DATABASE: linguacafe
+            MYSQL_USER: linguacafe
+            MYSQL_PASSWORD: linguacafe
+            MYSQL_ROOT_PASSWORD: linguacafe
+            SERVICE_NAME: linguacafe
         healthcheck:
             test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
             interval: 15s

--- a/docker/PhpDockerfile
+++ b/docker/PhpDockerfile
@@ -3,8 +3,9 @@ FROM php:8.2-apache
 RUN curl -sL https://deb.nodesource.com/setup_14.x -o nodesource_setup.sh \
     && chmod +x ./nodesource_setup.sh \
     && ./nodesource_setup.sh \
-    && rm ./nodesource_setup.sh \
-    && apt-get update \
+    && rm ./nodesource_setup.sh
+
+RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         curl \
         libonig-dev \
@@ -18,9 +19,10 @@ RUN curl -sL https://deb.nodesource.com/setup_14.x -o nodesource_setup.sh \
         zip \
         zlib1g-dev \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    # install php extensions for laravel
-    && docker-php-ext-install pdo pdo_mysql fileinfo \
+    && rm -rf /var/lib/apt/lists/*
+
+# install php extensions for laravel
+RUN docker-php-ext-install pdo pdo_mysql fileinfo \
     && docker-php-ext-configure gd \
     && docker-php-ext-install "-j$(nproc)" gd \
     && docker-php-ext-install pdo_mysql \

--- a/docker/PhpDockerfile
+++ b/docker/PhpDockerfile
@@ -22,7 +22,7 @@ RUN curl -sL https://deb.nodesource.com/setup_14.x -o nodesource_setup.sh \
     # install php extensions for laravel
     && docker-php-ext-install pdo pdo_mysql fileinfo \
     && docker-php-ext-configure gd \
-    && docker-php-ext-install "-j$(nproc) gd" \
+    && docker-php-ext-install "-j$(nproc)" gd \
     && docker-php-ext-install pdo_mysql \
     && docker-php-ext-install mysqli \
     && docker-php-ext-install zip \

--- a/docker/PhpDockerfile
+++ b/docker/PhpDockerfile
@@ -1,36 +1,38 @@
 FROM php:8.2-apache
 
-RUN curl -sL https://deb.nodesource.com/setup_14.x -o nodesource_setup.sh
-RUN chmod +x ./nodesource_setup.sh
-RUN ./nodesource_setup.sh
-RUN rm ./nodesource_setup.sh
-RUN apt install nodejs npm -y
-
-# install php extensions for laravel
-RUN apt update
-RUN apt install -y sqlite3
-RUN docker-php-ext-install pdo pdo_mysql fileinfo
-RUN apt install -y \
+RUN curl -sL https://deb.nodesource.com/setup_14.x -o nodesource_setup.sh \
+    && chmod +x ./nodesource_setup.sh \
+    && ./nodesource_setup.sh \
+    && rm ./nodesource_setup.sh \
+    && apt-get update \
+    && apt-get install --no-install-recommends -y \
+        curl \
+        libonig-dev \
         libpng-dev \
-        zlib1g-dev \
         libxml2-dev \
         libzip-dev \
-        libonig-dev \
-        zip \
-        curl \
+        nodejs \
+        npm \
+        sqlite3 \
         unzip \
+        zip \
+        zlib1g-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    # install php extensions for laravel
+    && docker-php-ext-install pdo pdo_mysql fileinfo \
     && docker-php-ext-configure gd \
-    && docker-php-ext-install -j$(nproc) gd \
+    && docker-php-ext-install "-j$(nproc) gd" \
     && docker-php-ext-install pdo_mysql \
     && docker-php-ext-install mysqli \
     && docker-php-ext-install zip \
     && docker-php-source delete
 
 #php config
-RUN printf 'max_execution_time = 600\n' >> /usr/local/etc/php/conf.d/uploads.ini
-RUN printf 'upload_max_filesize = 500M\n' >> /usr/local/etc/php/conf.d/uploads.ini
-RUN printf 'post_max_size = 500M\n' >> /usr/local/etc/php/conf.d/uploads.ini
-RUN printf 'memory_limit = 500M\n' >> /usr/local/etc/php/conf.d/uploads.ini
+RUN printf 'max_execution_time = 600\n' >> /usr/local/etc/php/conf.d/uploads.ini \
+    && printf 'upload_max_filesize = 500M\n' >> /usr/local/etc/php/conf.d/uploads.ini \
+    && printf 'post_max_size = 500M\n' >> /usr/local/etc/php/conf.d/uploads.ini \
+    && printf 'memory_limit = 500M\n' >> /usr/local/etc/php/conf.d/uploads.ini
 
 # copy apache config
 COPY ./docker/vhost.conf /etc/apache2/sites-available/000-default.conf
@@ -38,14 +40,12 @@ COPY ./docker/vhost.conf /etc/apache2/sites-available/000-default.conf
 COPY ./ /var/www/html
 
 # set project directory owner
-RUN chown -R www-data:www-data /var/www/html
-
-# enable htaccess
-RUN a2enmod rewrite
-
-# install composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN chown -R www-data:www-data /var/www/html \
+    # enable htaccess
+    && a2enmod rewrite \
+    # install composer
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 # for some reason i have to install this manually,
 # despite being in the composer.json

--- a/docker/PythonDockerfile
+++ b/docker/PythonDockerfile
@@ -6,8 +6,9 @@ RUN apt-get update -y \
         python3 \
         pip \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && pip install -U --no-cache-dir \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install -U --no-cache-dir \
         setuptools \
         wheel \
 #youtube api

--- a/docker/PythonDockerfile
+++ b/docker/PythonDockerfile
@@ -1,40 +1,39 @@
 FROM ubuntu:22.04
 
 WORKDIR /app
-RUN apt clean
-RUN apt update -y
-
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        python3 \
+        pip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install -U --no-cache-dir \
+        setuptools \
+        wheel \
 #youtube api
-RUN apt install python3 -y
-RUN apt install pip -y
-RUN pip install youtube_transcript_api
-
+        youtube_transcript_api \
 #ebook library
-RUN pip install ebooklib
-
-#spacy
-RUN pip install -U pip setuptools wheel
-RUN pip install -U spacy
-RUN python3 -m spacy download ja_core_news_sm
-RUN python3 -m spacy download ko_core_news_sm
-RUN python3 -m spacy download de_core_news_sm
-RUN python3 -m spacy download nb_core_news_sm
-RUN python3 -m spacy download es_core_news_sm
-RUN python3 -m spacy download zh_core_web_sm
-RUN python3 -m spacy download nl_core_news_sm
-RUN python3 -m spacy download fi_core_news_sm
-RUN python3 -m spacy download fr_core_news_sm
-RUN python3 -m spacy download it_core_news_sm
-RUN python3 -m spacy download ru_core_news_sm
-RUN python3 -m spacy download sv_core_news_sm
-RUN python3 -m spacy download uk_core_news_sm
-
-
+        ebooklib \
 #pykakasi
-RUN pip install pykakasi
-
+        pykakasi \
 #django
-RUN pip install django
+        django \
+#spacy
+        spacy
+
+RUN python3 -m spacy download ja_core_news_sm \
+    && python3 -m spacy download ko_core_news_sm \
+    && python3 -m spacy download de_core_news_sm \
+    && python3 -m spacy download nb_core_news_sm \
+    && python3 -m spacy download es_core_news_sm \
+    && python3 -m spacy download zh_core_web_sm \
+    && python3 -m spacy download nl_core_news_sm \
+    && python3 -m spacy download fi_core_news_sm \
+    && python3 -m spacy download fr_core_news_sm \
+    && python3 -m spacy download it_core_news_sm \
+    && python3 -m spacy download ru_core_news_sm \
+    && python3 -m spacy download sv_core_news_sm \
+    && python3 -m spacy download uk_core_news_sm
 
 COPY ./tools/django_server /app
 


### PR DESCRIPTION
This is for the most part, a refactor of the dockerfiles to follow most* of the best practices:

- Successive `RUN` commands have been consolidated into groups according to what they do.
- Quotes were added where words could be split.
- Setup is done to ensure build fails if command before pipe fails to prevent a potentially "corrupted" image.
- `pip`now installs packages without cache.
- `apt-get` is used instead of `apt` and its cache is cleared at the end.

Those two last points allowed images to down from 1.70 GB and 1.42 GB to 1.26 GB and 1.17 GB on my fork, a little more than a 20% reduction.

This PR also removes the `.dockerignore` file added earlier since now that persistent files never touch the repo it serves no purpose. A lot of those `.gitignore` files scattered around could be deleted too but that's for another day.

Finally, it formats `docker-compose.yml` to have consistent quotation marks and indentation.

*Docker best practices also advise to pin packages versions wherever possible, but I have decided against it as per not to introduce the burden of bumping versions in a timely fashion.