### PR TITLE
feat: reduce image size using a multi stage build

### DIFF
--- a/docker/PhpDockerfile
+++ b/docker/PhpDockerfile
@@ -1,11 +1,12 @@
+FROM node:20-alpine as node_build
+
+WORKDIR /build
+COPY ./ /build
+RUN npm install && npm run prod
+
 FROM php:8.2-apache
 
 ENV COMPOSER_ALLOW_SUPERUSER=1
-
-RUN curl -sL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh \
-    && chmod +x ./nodesource_setup.sh \
-    && ./nodesource_setup.sh \
-    && rm ./nodesource_setup.sh
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
@@ -53,14 +54,9 @@ COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
 # despite being in the composer.json
 # RUN composer require guzzlehttp/guzzle
 
-RUN composer install --optimize-autoloader --no-dev\
-    && npm install \
-    && npm run prod \
-    && rm -rf /usr/local/share/.cache \
-        /root/.npm \
-        /tmp/* \
-        /usr/local/bin/composer \
-        /var/www/html/node_modules
+RUN composer install --optimize-autoloader --no-dev
+
+COPY --from=node_build --chown=www-data:www-data /build/public /var/www/html/public
 
 ENTRYPOINT ["/var/www/html/entrypoint.sh"]
 CMD ["apache2-foreground"]


### PR DESCRIPTION
This commit moves the compiling of the JavaScript code into a separate container, from which it is copied over to the final image to ensure no JavaScript dependencies are bloating the end result. On first testing this reduced image size by around 400MB.

I will do more testing for some days since it is hard to believe this 35~ish percent reduction didn't break anything.

I also noticed I had permission issues with the Laravel log despite me running `chmod -R ./ 777` on the folder after pulling but before starting the container; I will look into whatever is going on there.