### PR TITLE
update restart policy of webserver container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     webserver:
         image: ghcr.io/simjanos-dev/linguacafe-webserver:main
         container_name: linguacafe-webserver
+        restart: unless-stopped
         depends_on:
             - mysql
         volumes:


### PR DESCRIPTION
The update policy of the database and python containers are `unless-stopped`, while webserver's is `no` by default, which requires manually restarting the container from time to time to access LinguaCafe. This change updates the restart policy of webserver to `unless-stopped`.