### PR TITLE
feat: change the action from build on commit to main to build on release

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -16,14 +16,14 @@
 name: Build and Publish Docker images
 
 # If you want to push images on every git push to the repo:main branch
-on:
-  push:
-    branches: main
+# on:
+#   push:
+#     branches: main
 
 ## If you want to push images only on a new tag/release
-# on:
-#   release:
-#     types: [created]
+on:
+  release:
+    types: [created]
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
This small change will make it so that images build and published to ghcr.io will be tagged with the name of their respective release tag, and the most recent one will have the 'latest' tag on top of it.

I'm not sure but I think when you first merge this to main it will trigger the old action and build an image with the "main" tag, and from there onward it will only build when doing a release. So if you do both things in quick succession the last of all "main" images will be the same as "v0.7".