### PR TITLE
feat: add compatibility with versioned images and local models

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ networks:
 
 services:
     webserver:
-        image: ghcr.io/simjanos-dev/linguacafe-webserver:${VERSION:-main}
+        image: ghcr.io/simjanos-dev/linguacafe-webserver:${VERSION:-latest}
         container_name: linguacafe-webserver
         restart: unless-stopped
         depends_on:
@@ -45,7 +45,9 @@ services:
         command: /app/manage.py runserver 0.0.0.0:8678
         restart: unless-stopped
         tty: true
-        image: ghcr.io/simjanos-dev/linguacafe-python-service:${VERSION:-main}
+        image: ghcr.io/simjanos-dev/linguacafe-python-service:${VERSION:-latest}
+        environment:
+            PYTHONPATH: "${PYTHONPATH}:/var/www/html/storage/models"
         volumes:
             - ./storage:/var/www/html/storage
         networks:

--- a/storage/models/.gitignore
+++ b/storage/models/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This commit changes the default tag pulled by the images from 'main' to 'latest', which will be automatically given to the most recent image built from the latest release, while also enabling it to be changed to a specific version by specifying it in a .env file.

It also creates the new models directory to store the Spacy files for the extra languages, and modifies the PYTHONPATH environment variable to append this folder to it.

This will remain a draft until we figure out every little detail about locally installing models, specially since people pulling this before the 0.7 release will have it break on them (can be solved by changing the version in the .env file).