### PR TITLE
fix: commenting in and out is no longer needed and silenced warning

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,9 +47,9 @@ services:
         tty: true
         image: ghcr.io/simjanos-dev/linguacafe-python-service:${VERSION:-latest}
         environment:
-            PYTHONPATH: "${PYTHONPATH}:/var/www/html/storage/models"
+            PYTHONPATH: "/var/www/html/storage/app/model"
         volumes:
             - ./storage:/var/www/html/storage
         networks:
             - linguacafe
-        # platform: linux/amd64
+        platform: ${PLATFORM:-}


### PR DESCRIPTION
This commit makes it so that users of Apple Silicon no longer need to comment out a line to run the python container nor remember to comment it back in when updating; the process is now handled by an enviroment variable like all the other deployment settings.

It also silences a warning when trying to append a directory to the PYTHONPATH environment variable inside the container because the variable is not set up by default. Now it is simply overwritten.