### PR TITLE
[Proposal] Add initial LinguaCafe's manual

### DIFF
--- a/manual/README.md
+++ b/manual/README.md
@@ -1,0 +1,37 @@
+# LinguaCafe's User Manual
+
+> [!NOTE]  
+> This manual was written for v0.7, and it's possible latest improvements haven't been documented yet. Please report any feature that haven't documented yet on LinguaCafe's [**issue tracker**](https://github.com/simjanos-dev/LinguaCafe/issues).
+
+## Table of Contents
+
+- [Introduction](./introduction.md)
+- [Background](./background.md)
+- [Screenshots](./screenshots.md)
+- [Supported Platforms](./supported-platforms.md)
+- **Installation**
+	- [Installation](./installation.md)
+	- [Updating LinguaCafe](./updating-linguacafe.md)
+	- [Installation troubleshooting](./installation-troubleshooting.md)
+- **Features**
+	- [Languages](feature-languages.md)
+	- [Library](feature-library.md)
+	- [Reading](./feature-reading.md)
+	- [Review](./feature-review.md)
+	- [Goal tracking](./feature-goal-tracking.md)
+	- [Vocabulary](./feature-vocabulary.md)
+	- [Dictionaries](./feature-dictionaries.md)
+	- [Kanji and radicals](./feature-kanji-and-radicals.md)
+	- [Anki](./feature-anki-support.md)
+	- [Themes and customization](./feature-themes-and-customization.md)
+- **Usage**
+	- [Importing dictionaries](./importing-dictionaries.md)
+	- [Importing vocabulary into LinguaCafe](./importing-vocabulary.md)
+	- [Configuring Jellyfin](./configuring-jellyfin.md)
+	- [Backup](./backup.md)
+- [**FAQ**](faq.md)
+- **Miscellaneous**
+	- [Changelog](./changelog.md)
+	- [Backlog](./backlog.md)
+	- [Migration](../migration.md)
+	- [Documentation feedback](./documentation-feedback.md)

--- a/manual/background.md
+++ b/manual/background.md
@@ -1,0 +1,20 @@
+# Background
+
+LinguaCafe is a self-hosted web-app for learning foreign languages by reading.
+
+In summary, you import foreign language texts into LinguaCafe from ebooks, websites, etc., and read through them, creating saved definitions and associations for words as you read. As you read more, you continue to build your personal dictionary.
+  
+I developed LinguaCafe mainly for personal use, because I found the alternative platforms too expensive or lacking in features I wanted.  After years of development and reading other language learners' opinions about similar platforms, I realized that it might also be a useful tool for other learners, so I have started adding more features to grow LinguaCafe into a platform that more people can benefit from.  
+
+With LinguaCafe you:
+- **Can read the source code and contribute features.** LinguaCafe is an open-source software, which means the code is readily available to you, you can copy it and use it according to the license, and contribute features.
+- **Can self-host.** LinguaCafe is self-hosted, web app which means it runs in your machine or potentially in a private web server and thus be accessible to you in the internet.
+- **Control your data.** Because you host LinguaCage yourself in your machine, you own your data and can do whatever you want with it. 
+- **Free.** LinguaCafe doesn't have a price tag, it is a free as in *free beer*.
+
+
+## LinguaCage alternatives
+- [LingQ](https://www.lingq.com/) - a commercial product
+- [Lute v3](https://github.com/jzohrab/lute-v3)
+- [LWT](https://github.com/HugoFara/lwt)
+- [Readlang](https://readlang.com/)

--- a/manual/backlog.md
+++ b/manual/backlog.md
@@ -1,0 +1,3 @@
+# Backlog
+
+LinguaCafe's backlog can be found on [GitHub's **Issues**](https://github.com/simjanos-dev/LinguaCafe/issues) page.

--- a/manual/backup.md
+++ b/manual/backup.md
@@ -1,0 +1,54 @@
+# Backup
+
+>[!IMPORTANT]
+>
+>This guide assumes you named your directory `linguacafe` during [installation](./installation.md). If you used a different name for your directory, simply replace `linguacafe` with it.
+
+LinguaCafe stores your data in two directories:
+- `linguacafe/storage` directory, which stores your files.
+- `linguacafe/database` directory, which stores your database files.
+
+Both must be saved to preserve all your LinguaCafe data.
+
+To make a backup of your LinguaCafe instance, simply copy your whole `linguacafe` directory. On Linux you may need root privileges to copy the `database` folder, so please make sure that it was successful. Also make sure that the permissions are the same after restoring your data. You can reapply them by using the `chmod` command from the [installation guide](./installation.md).
+
+>[!WARNING]
+> **Backup your database regularly!** I highly recommend making regular backups, especially before upgrading LinguaCafe to a newer version. LinguaCafe is still in active development, and there is a higher possibility of introducing a data corrupting bug.
+
+## Exporting the LinguaCafe's database
+
+Although copying the whole database folder works, you might also want to make a raw export of your database in order to remove the dependency on a functioning MySql docker container. This way you can have your database data in a single `.sql` file, e.g., `linguacafe-backup.sql`.
+
+Run this command while your LinguaCafe server is running to export your database (If your database setup was changed manually, change names accordingly):
+
+>[!TIP] 
+>
+>If you run `docker ps -a`, then you should get all running Docker containers, among which there's `linguacafe-database` or a similarly named container, in which the database is running.
+>
+
+```
+docker exec DATABASE-CONTAINER mysqldump --no-tablespaces -uUSERNAME -pPASSWORD DATABASE > ./linguacafe-backup.sql
+```
+
+where `DATABASE-CONTAINER`, `USERNAME`, and `PASSWORD` should be replaced with the names you used during [installation](./installation.md). If you kept the default names, then the command is simply:
+
+```
+docker exec linguacafe-database mysqldump --no-tablespaces -ulinguacafe -plinguacafe linguacafe > ./linguacafe-backup.sql
+```
+
+Now there should be a `lingucafe-backup.sql` under the `linguacafe` directory.
+## Importing the LinguaCafe's database
+
+You can import it back with the following command:  
+
+```
+docker exec -i DATABASE-CONTAINER mysql -uUSERNAME -pPASSWORD DATABASE < ./linguacafe-backup.sql`
+```
+
+where `DATABASE-CONTAINER`, `USERNAME`, and `PASSWORD` should be replaced with the names you used during [installation](./installation.md). If you kept the default names, then the command is simply:
+
+```
+docker exec -i linguacafe-database mysql -ulinguacafe -plinguacafe linguacafe < ./linguacafe-backup.sql`
+```
+
+Now there should be a `lingucafe-backup.sql` under the `linguacafe` directory.

--- a/manual/changelog.md
+++ b/manual/changelog.md
@@ -1,0 +1,3 @@
+# Changelog
+
+LinguaCafe's changelog can be found on [Github's **Releases**](https://github.com/simjanos-dev/LinguaCafe/releases) page.

--- a/manual/configuring-jellyfin.md
+++ b/manual/configuring-jellyfin.md
@@ -1,0 +1,90 @@
+# Jellyfin
+## Jellyfin configuration
+
+You can use the network configuration from this example to connect Jellyfin's network with LinguaCafe. There are probably multiple ways to do it, the only requirement is that `linguacafe-webserver` should be able to reach Jellyfin's server to make API requests.
+
+```
+version: '3.5'
+networks:
+    linguacafe_linguacafe:
+        external: true
+
+services:
+    jellyfin:
+        image: jellyfin/jellyfin
+        container_name: jellyfin
+        user: 1000:1000
+        volumes:
+            - /path/to/config:/config
+            - /path/to/cache:/cache
+            - /path/to/media:/media:ro
+        restart: 'unless-stopped'
+        ports:
+            - 8096:8096
+        networks:
+            - linguacafe_linguacafe
+```
+
+You must name your subtitle files in a way that Jellyfin will recognize as languages. These worked for me: 
+
+```
+Series Name - S01E01.ja.ass  
+Series Name - S01E01.de.ass  
+Movie name.es.ass  
+```  
+
+Language codes for subtitle filenames that Jellyfin recognizes:
+
+| Language | Language Code |
+| :--- | ---- |
+| Chinese | `zh` |
+| Czech | `cs` |
+| Dutch | `nl` |
+| Finnish | `fi` |
+| French | `fr` |
+| German | `de` |
+| Italian | `it` |
+| Japanese | `ja` |
+| Korean | `ko` |
+| Norwegian | `no` |
+| Russian | `ru` |
+| Spanish | `es` |
+| Swedish | `sv` |
+| Ukrainian | `uk` |
+| Welsh | `cy` |
+
+See [Jellyfin external file naming](https://jellyfin.org/docs/general/server/media/external-files/).
+
+## Jellyfin API usage
+
+1. Create an API key in Jellyfin. You can do this on the **Dashboard** > **API Keys** menu.
+2. Set the created API key in LinguaCafe on to the **Admin** > **API** menu.
+3. Set the Jellyfin host in LinguaCafe on to the **Admin** > **API** menu. If you used the pre-written configs, it should be the default http://jellyfin:8096.
+4. Save the settings.
+
+Now you can import subtitles from Jellyfin.
+## Jellyfin troubleshooting
+
+Possible error codes in browser console while importing from Jellyfin:
+
+<details>
+<summary><b>Error: unsupported language code: spa</b></summary>
+
+This means that Jellyfin recognized the language of the subtitle, but it is not supported by LinguaCafe yet. If you find one of these, please open a GitHub Issue, this should be fixed. 
+
+</details>
+
+<details>
+<summary><b>Error: unsupported language code: unrecognized by jellyfin: japaaaneseee</b></summary>
+
+This means that Jellyfin did not recognize `japaaaneseee` as a language, and it can only be fixed by renaming the file following Jellyfin's naming conventions. 
+
+If you have file naming issues and renamed a file, make sure you refresh metadata in Jellyfin before reloading LinguaCafe.
+
+</details>
+
+
+
+
+
+

--- a/manual/documentation-feedback.md
+++ b/manual/documentation-feedback.md
@@ -1,0 +1,3 @@
+# Documentation feedback
+
+If this documentation is unclear or has an error, please open a new [GitHub's Issue](https://github.com/simjanos-dev/LinguaCafe/issues/new). To avoid duplicate issues, check if a similar issue has already been submitted.

--- a/manual/faq.md
+++ b/manual/faq.md
@@ -1,0 +1,13 @@
+# Frequently Asked Questions (FAQ)
+
+### How can I tell a known word and an ignored word apart?
+
+In the default themes, both known and ignored words aren't highlighted and they appear alike in the text. However if you click a word, the **Vocabulary sidebar** shows the word's level. A word whose level is a checkmark is a **known** word while a word with a cross is an **ignored** word. Ignored words do not count in learned word statistics.
+
+### Do words that were imported with a specific source get deleted if I delete the source?
+
+TBD.
+
+### How much memory does LinguaCafe use?
+
+LinguaCafe uses RAM based on how many and which languages do you use. If you use every language, the RAM usage can be over 2GB.

--- a/manual/feature-anki-support.md
+++ b/manual/feature-anki-support.md
@@ -1,0 +1,10 @@
+# Anki
+
+Currently Anki is supported if your server and Anki run on the same PC and have the [AnkiConnect](https://ankiweb.net/shared/info/2055492159) plugin installed.
+
+To set up an Anki's connection, head over to **Admin** > **API** >**Anki**.
+
+>[!NOTE]
+>
+>Future versions of LinguaCafe won't have this requirement.
+

--- a/manual/feature-dictionaries.md.md
+++ b/manual/feature-dictionaries.md.md
@@ -1,0 +1,7 @@
+# Dictionaries
+
+LinguaCafe comes with no dictionary files by default, but you can download and import them from different sources. Check [Importing dictionaries](./importing-dictionaries.md) for how to implement dictionaries into LinguaCafe.
+
+![Dictionaries](/GithubImages/LibraryCover.jpg)
+
+You can also use DeepL translator, which allows you to translate 500.000 characters/month for free with machine translation.

--- a/manual/feature-goal-tracking.md
+++ b/manual/feature-goal-tracking.md
@@ -1,0 +1,7 @@
+# Goal Tracking
+
+LinguaCafe tracks how many words you read, highlight and review daily. You can view and edit your daily goals on the **Home page**, and you can see your progress over time on the **Calendar**.  
+  
+![Goal Tracking](/GithubImages/LibraryCover.jpg)
+  
+You can also view your all time statistics on the bottom of **Home page**.

--- a/manual/feature-kanji-and-radicals.md
+++ b/manual/feature-kanji-and-radicals.md
@@ -1,0 +1,5 @@
+# Kanji and radicals
+
+You can view information about the kanji you know.
+
+![Kanji and radicals](/GithubImages/LibraryCover.jpg)

--- a/manual/feature-languages.md
+++ b/manual/feature-languages.md
@@ -1,0 +1,32 @@
+# Languages
+
+In LinguaCafe all the data are separated by the selected language. This means that any action you take in one language will not affect the data in other languages, so the first thing you should do in LinguaCafe is select your target language. You can change your selected language by clicking on the flag in the bottom left corner.
+
+When you import text, LinguaCafe does:
+- **Lemma generation:** When you import a text into LinguaCafe, the text processor will automatically assign dictionary form to words for supported languages. For example, it will assign the lemma `to work` to words such as `worked`.
+- **Gender tagging:** In gendered and supported languages, LinguaCafe will prepend nouns with additional information based on the words' gender. 
+
+## Supported Languages
+
+LinguaCafe supports the following languages:
+
+| Flag                                                          | Language  | DeepL   | Lemma generation | Gender tagging | Dictionaries          |
+|:-------------------------------------------------------------:|:---------:|:-------:|:----------------:|:-------------------:|-----------------------|
+| <img src='../public/images/flags/chinese.png' width='25'>   | Chinese   | &check; |                  |                     | wiktionary, cc-cedict |
+| <img src='../public/images/flags/czech.png' width='25'>     | Czech     | &check; |                  |                     | wiktionary, dict cc   |
+| <img src='../public/images/flags/dutch.png' width='25'>     | Dutch     | &check; | &check;          |                     | dict cc               |
+| <img src='../public/images/flags/finnish.png' width='25'>   | Finnish   | &check; | inaccurate       |                     | wiktionary, dict cc   |
+| <img src='../public/images/flags/french.png' width='25'>    | French    | &check; | &check;          |                     | wiktionary, dict cc   |
+| <img src='../public/images/flags/german.png' width='25'>    | German    | &check; | &check;          | &check;             | wiktionary, dict cc   |
+| <img src='../public/images/flags/italian.png' width='25'>   | Italian   | &check; | &check;          |                     | wiktionary, dict cc   |
+| <img src='../public/images/flags/japanese.png' width='25'>  | Japanese  | &check; | &check;          |                     | jmdict, wiktionary    |
+| <img src='../public/images/flags/korean.png' width='25'>    | Korean    | &check; | &check;          |                     | wiktionary, kengdic   |
+| <img src='../public/images/flags/norwegian.png' width='25'> | Norwegian | &check; | &check;          | &check;             | wiktionary, dict cc   |
+| <img src='../public/images/flags/russian.png' width='25'>   | Russian   | &check; | &check;          |                     | wiktionary, dict cc   |
+| <img src='../public/images/flags/spanish.png' width='25'>   | Spanish   | &check; | &check;          |                     | wiktionary, dict cc   |
+| <img src='../public/images/flags/swedish.png' width='25'>   | Swedish   | &check; | &check;          |                     | dict cc               |
+| <img src='../public/images/flags/ukrainian.png' width='25'> | Ukrainian | &check; |                  |                     | wiktionary            |
+| <img src='../public/images/flags/welsh.png' width='25'>     | Welsh     |         |                  |                     | wiktionary, eurfa     |
+
+> [!NOTE]  
+> Chinese: Mandarin language with simplified Chinese characters.

--- a/manual/feature-library.md
+++ b/manual/feature-library.md
@@ -1,0 +1,60 @@
+# Library
+
+LinguaCafe allows you to manage all imported texts on the **Library** page. The imported texts are arranged and labeled as **books** and **chapters**, but they can be anything like subtitles, podcast transcripts or news articles.  
+
+Each book and chapter shows a count for unique words, known words, highlighted words, and new words, all of which allows you to estimate how difficult a text will be for your level.
+## Books
+
+LinguaCafe organizes your reading content into **books** with **chapters**, however it uses the term **book** in a broader sense because the imported text can come from different  sources:
+- Plain text
+- Text file
+- E-book file
+- Youtube subtitle
+- Subtitle file
+- Jellyfin's external subtitle
+- Webpage
+
+Whenever you import some text into LinguaCafe, regardless of the source, you've the choice to
+* **Select its library location.** You can choose to add a new chapter to an already existing book, or create an entirely different book. 
+* **Select how the text is processed and split.** You can use either the **Simple** or **Detailed** process, which determines whether the processed text will be enriched with additional information such as dictionary form, gender, or reading. You can also set the **Maximum number of characters per chapter**; by default, the maximum number of characters is set to 3000 and there's a maximum of 15000. 
+
+## Imported text types
+### Plain text
+
+LinguaCafe allows you to paste text directly into a simple editor, which you can make into a chapter.
+
+![Importing plain text into LinguaCafe](/GithubImages/LibraryCover.jpg)
+
+### Text file
+
+LinguaCafe allows you to upload a text file, edit its content, and then make into a chapter.
+
+![Importing text from a text file into LinguaCafe](/GithubImages/LibraryCover.jpg)
+
+### Ebook file
+
+LinguaCafe allows you to upload an ebook file and make into a book. Currently only EPUB files are accepted.
+
+
+![Importing text an ebook file into LinguaCafe](/GithubImages/LibraryCover.jpg)
+### Youtube subtitle
+
+LinguaCafe allows you to import the subtitle from a Youtube video by simply pasting the video URL into the **Youtube url** field and pressing <kbd>Enter</kbd> in your keyboard. This will grab the video's subtitle, which you can then edit, and make into a chapter.
+
+![Importing text from a Youtube video into LinguaCafe](/GithubImages/LibraryCover.jpg)
+
+### Subtitle file
+
+LinguaCafe allows you to import text from subtitle file, which you can edit, and make into a chapter. 
+
+![Importing text from a subtitle file into LinguaCafe](/GithubImages/LibraryCover.jpg)
+### Jellyfin's external subtitle
+
+LinguaCafe allows you to import the text from a Jellyfin's external subtitle file, which you can make into a chapter. See [Configuring Jellyfin](./configuring-jellyfin.md) for more info on how to configure it.
+
+![Importing text from Jellyfin's external subtitle file into LinguaCafe](/GithubImages/LibraryCover.jpg)
+### Webpage
+
+LinguaCafe allows you to import the text from a website using the page URL. You simply paste the URL into the **Website url** field and press <kbd>Enter</kbd> in your keyboard. This will grab the page's text, which you can then edit, and make into a chapter.
+
+![Importing text from a webpage into LinguaCafe](/GithubImages/LibraryCover.jpg)

--- a/manual/feature-reading.md
+++ b/manual/feature-reading.md
@@ -1,0 +1,29 @@
+# Reading
+
+Supplementing your language learning with LinguaCafe boils down to reading and reviewing the words you're learning in context. When you first start reading, all your words will be new, which means you haven't seen them before in LinguaCafe.  
+
+Whenever you select a word you don't know, and you add a translation for it, be it from the built-in vocabulary search or manually, you will start to learn this word. As you review the words you're learning, you start getting closer to learning them. Once you learn a word, this word becomes known.
+
+There are words you don't want to learn or simply want to ignore, for example proper nouns, foreign words, etc, which is why LinguaCafe also allows you to ignore words, in which case they won't count towards the learned word statistics.
+
+We can summarize the words by level in LinguaCafe as follows:
+- **New**, words that you haven't seen before, or haven't started to learn yet.
+- **Learning**, words that you're currently learning. LinguaCafe uses integers in the range from 1 to 7 to determine how often these should appear in reviews. The closer a word is to 0, the closer you're to learning it and the less it appears in reviews.
+- **Known**, words that have reached the level 0 via reviews or that you checked in the **Vocabulary sidebar** by clicking the checkmark.
+- **Ignored**, words that you've explicitly ignored by clicking the cross in the **Vocabulary sidebar**. 
+
+New words and words you're currently learning are highlighted, however the colors used depend on the theme you're using. Here's a summary for the default themes:
+
+| Theme | New | Learning | Known | Ignored |
+| :--- | :--- | ---- | ---- | ---- |
+| Light | Yellow | Green | No highlighting | No highlighting |
+| Dark | Yellow | Green | No highlighting | No highlighting |
+| Eink | Underlined | Black | No highlighting | No highlighting |
+
+In addition to saving words, LinguaCafe also allows you to save multiple words as a **phrase**. With your mouse, left-click on a word and drag it onto the next one until you've selected all the adjacent words you want. When you're done selecting words, the **New phrase** pop-up will come up where you can add a translation for the phrase, set its level, and save it.
+
+When you reach the end of a chapter, you can click the **Finished reading** button to set all words in the chapter to known. 
+
+>[!CAUTION]
+>The effect of clicking the **Finished reading** button cannot be undone, thus exercise some caution when clicking it. If you don't know all the words in the chapter and/or you don't want to set them all to known, then don't click it. Words that have been set to anything, such as known, cannot be reverted back to new.
+

--- a/manual/feature-review.md
+++ b/manual/feature-review.md
@@ -1,0 +1,7 @@
+# Review
+
+After reading your texts and creating highlighted words and phrases, you can review them on the **Review page**. You can review words from a specific **book**, **chapter**, or you can review them all at once.  
+
+![Review](/GithubImages/LibraryCover.jpg)
+
+LinguaCafe uses a spaced repetition system (SRS) similar to the Leitner system, but you can export your highlighted cards to Anki or other SRS software if you want. To update LinguaCafe's SRS settings, head over to **Admin** > **Reviews**, and follow the instructions.

--- a/manual/feature-themes-and-customization.md
+++ b/manual/feature-themes-and-customization.md
@@ -1,0 +1,6 @@
+# Themes and customization
+
+LinguaCafe comes with a light, dark and e-ink theme.  
+  
+Mobile view is also supported. You can use LinguaCafe from any device that has a browser and at least 340px wide screen.
+

--- a/manual/feature-vocabulary.md.md
+++ b/manual/feature-vocabulary.md.md
@@ -1,0 +1,5 @@
+# Vocabulary
+
+In LinguaCafe, you can search, edit and export your words on the **Vocabulary** page.
+
+![Vocabulary](/GithubImages/LibraryCover.jpg)

--- a/manual/importing-dictionaries.md
+++ b/manual/importing-dictionaries.md
@@ -1,0 +1,30 @@
+# Importing dictionaries
+
+1. Download the dictionaries that you want to use from the provided links below.
+2. Copy the dictionary files to your `linguacafe/storage/app/dictionaries` folder.
+3. Go to the Admin -> Dictionaries page in LinguaCafe. Click on the `Import dictionary` button.
+4. This dialog will list all your importable dictionaries that are found in your `dictionaries` folder. Click on the `import` button for the dictionary that you want to import.
+
+After the import process is finished, your dictionary should be working.
+
+## Dictionaries
+
+| Dictionary | Languages | Download | Required Files | Comment |
+| :--- | ---- | ---- | ---- | ---- |
+| JMDict | Japanese | [GitHub release](https://github.com/simjanos-dev/LinguaCafe/releases/tag/dictionaries) | `jmdict_processed.txt`, `kanjidic2.xml`, `radical-strokes.txt`, `radicals.txt` | This dictionary contains kanji and radicals for the Japanese language. Some Japanese features do not work without importing this dictionary. |
+| CC-CEDICT | Chinese |  [GitHub release](https://github.com/simjanos-dev/LinguaCafe/releases/tag/dictionaries) |  |  |
+| Kengdic | Korean | [GitHub release](https://github.com/simjanos-dev/LinguaCafe/releases/tag/dictionaries) |  |  |
+| Eurfa | Welsh | [GitHub release](https://github.com/simjanos-dev/LinguaCafe/releases/tag/dictionaries) |  |  |
+|  Wiktionary | Chinese, Czech, Finnish, French, German, Italian, Japanese, Korean, Norwegian, Russian, Spanish, Ukrainian, Welsh | [GitHub release](https://github.com/simjanos-dev/LinguaCafe/releases/tag/dictionaries) |  |  |
+| Dict.cc | Czech, Dutch, Finnish, French, German, Italian, Norwegian, Russian, Spanish, Swedish | [dict.cc](https://www1.dict.cc/translation_file_request.php?l=e) |  | This dictionary's license only allows personal use. |
+
+## Custom dictionary
+
+You can also import a custom dictionary file in the form of a `.csv` file.
+
+## DeepL translate
+
+DeepL is a machine translation service that lets you translate up to 500.000 characters/month for free and is supported by LinguaCafe. You can set your DeepL Translate API key in the admin API settings.
+
+You must enable DeepL translate for each language on the Admin -> Dictionaries page.
+

--- a/manual/importing-vocabulary.md
+++ b/manual/importing-vocabulary.md
@@ -1,0 +1,26 @@
+# Importing Vocabulary into LinguaCafe
+
+If you have a list of words that you already know before you started using LinguaCafe, you can import them from a CSV file.
+
+>[!CAUTION]
+>
+> Changes after importing cannot be reverted, thus make sure you're importing only the words you want LinguaCafe to track.
+
+To import words, go to the **Vocabulary** page, select the **Data** dropdown menu, and inside that click on the **Import** button. On the import dialog you can select your CSV file and a few options: 
+- **Skip first row**. If enabled, LinguaCafe skips the first row which could be simply be the column names.
+- **Only update**. If enabled, no new words will be added to the system. This allows you to only update fields for words that you have already encountered in LinguaCafe.
+
+The CSV file can have these columns, in this order:
+
+| Column Name | Required | Accepted Values | Comment |
+| :--- | :--- | :--- | :--- |
+| Word | Yes | Any word without any spaces. |  |
+| Translation | No |  | Can be left empty. |
+| Lemma | No |  | Can be left empty. |
+| Reading | No |  | Can be left empty. |
+| Lemma reading | No |  | Can be left empty. |
+| Level | No | `new`, `ignored`, `learned`, `1`, `2`, `3`, `4`, `5`, `6`, `7` | Cannot be left empty. |
+
+At least the first column must be present in the CSV file. Any further columns can be added to it in the order showed above. If a column is not provided, those fields will not be changed in the database. However if a column is provided, and it's left empty in a row, it will be overwritten in the database with an empty value.
+
+After the import is complete, you will see a message about the number of created, updated and rejected words.

--- a/manual/installation.md
+++ b/manual/installation.md
@@ -1,0 +1,66 @@
+# Installation
+
+In order to proceed with the installation of LinguaCafe, it's recommended you've the following programs already installed in your computer:
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/), a containerization software to make LinguaCafe into a single container that can be started, stopped, and re-created.
+- [Git](https://git-scm.com/), a version manager system. This is most likely already installed in your machine. If it's not, you can use a package manager such as Homebrew if you're using MacOS or your distribution's packager manager if you're using Linux.
+
+Install them first, and then follow the steps below for your operating system. 
+## Linux/MacOS
+
+**Step 1:** Clone the LinguaCafe's repository and change into it.
+
+```
+git clone -b deploy https://github.com/simjanos-dev/LinguaCafe.git linguacafe && cd linguacafe
+```
+
+**Step 2:** If you want to change the default MySQL database and user, you can create a `.env` file and add these lines to it before starting your servers for the first time.
+
+```
+DB_DATABASE="linguacafe"
+DB_USERNAME="linguacafe"
+DB_PASSWORD="linguacafe"
+```
+
+**Step 3:** Change the permission for the entire directory, and then proceed to build and start the LinguaCafe service.
+
+> [!WARNING]  
+> Make sure Docker Desktop is already running before running the following command.
+
+```
+chmod -R 777 ./ && docker compose up -d
+```
+
+**Step 4:** Your server now should be running and accessible on http://localhost:9191.  Now open your web browser to `http://localhost:9191`.
+
+## Windows
+
+**Step 1:** Clone the LinguaCafe's repository and change into it.
+```
+git clone -b deploy https://github.com/simjanos-dev/LinguaCafe.git linguacafe && cd linguacafe
+```
+
+**Step 2:** If you want to change the default MySQL database and user, you can create a `.env` file and add these lines to it before starting your servers for the first time.
+
+```
+DB_DATABASE="linguacafe"
+DB_USERNAME="linguacafe"
+DB_PASSWORD="linguacafe"
+````
+
+**Step 3:** Change the permission for the entire directory, and then proceed to build and start the LinguaCafe service.
+
+> [!WARNING]  
+> Make sure Docker Desktop is already running before running the following command.
+
+```
+docker compose up -d
+```
+
+**Step 4:** Your server now should be running and accessible on http://localhost:9191.  Now open your web browser to `http://localhost:9191`.
+
+### Script-based Installation
+
+> [!IMPORTANT]  
+> The script is a `.bat` file, and Windows defender will warn you about it being potentially a malware.
+
+You can automate the installation and the LinguaCafe service startup by downloading and running the [Windows's LinguaCafe Installation script](/install_linguacafe.bat). 

--- a/manual/introduction.md
+++ b/manual/introduction.md
@@ -1,0 +1,13 @@
+# Introduction
+
+LinguaCafe is a free, web-based and self-hosted platform to help you read text in a foreign language. It provides you with a set of tools to read, look up, and review unknown words, and do so as effortlessly as possible.
+
+LinguaCafe contains a few core features to facilitate learning a language through reading:
+- Choosing languages and importing dictionaries.
+- Creating, importing, and editing text from source such as ebooks, websites, Youtube subtitles, etc.
+- Highlighting words, marking them as known, unknown, or completely ignoring them.
+- Reviewing words you're learning using LinguaCafe's own SRS implementation, or exporting them to Anki.
+
+You can find screenshots of LinguaCafe's different features [here](./screenshots.md). 
+
+

--- a/manual/screenshots.md
+++ b/manual/screenshots.md
@@ -1,0 +1,16 @@
+# Screenshots
+
+## Library
+
+![Library](/GithubImages/LibraryCover.jpg)
+## Reader
+
+![Reader](/GithubImages/TextReader.jpg)
+
+## Vocabulary review
+
+![Review](/GithubImages/ReviewBackCard.jpg)
+
+## Vocabulary search
+
+![Vocabulary](/GithubImages/VocabularySearch.jpg)

--- a/manual/supported-platforms.md
+++ b/manual/supported-platforms.md
@@ -1,0 +1,7 @@
+# Supported Platforms
+
+LinguaCafe is supported in the following platforms:
+- x64, which includes most desktop computers made in the last decade.
+- Macs with Apple silicon are supported, but need to uncomment the line that says `platform: linux/amd64` by removing the "#" near the end of the `docker-compose.yml`file. To do this, you will need to split the chained install command, first clone the repository, then uncomment the line, then run the rest of the commands. You will also need to comment it and uncomment it again for each update to avoid git conflict error.
+
+Other Armv8 devices such as Raspberry Pis 3 and newer are not supported yet.

--- a/manual/updating-linguacafe.md
+++ b/manual/updating-linguacafe.md
@@ -1,0 +1,27 @@
+# Updating LinguaCafe
+
+## V0.5.2 or below
+
+Please use the migration guide provided [here](/migration.md).
+## Above v0.5.2
+
+> [!WARNING]  
+> Before updating LinguaCafe, make a backup of the `linguacafe` folder (or the folder you used when setting up LinguaCafe for the first time). **If you don't back up your data, it might be lost forever.**
+
+### Linux  and MacOs
+
+In your terminal, run the following command:
+
+```
+git pull && docker compose pull && docker compose up -d --force-recreate
+```
+
+### Windows
+
+You can run either the [Windows's LinguaCafe Installation script](/install_linguacafe.bat) or run the following commands one by one:
+
+```
+git pull
+docker compose pull
+docker compose up -d --force-recreate
+```

--- a/package.json
+++ b/package.json
@@ -29,11 +29,12 @@
         "vue-template-compiler": "^2.6.12"
     },
     "dependencies": {
+        "@mdi/font": "^7.4.47",
         "@popperjs/core": "^2.11.6",
         "vue-cookie": "^1.1.4",
         "vue-router": "3.6.5",
+        "vue-showdown": "^2.4.1",
         "vue2-circle-progress": "1.2.3",
-        "vuetify": "^2.6.12",
-        "@mdi/font": "^7.4.47"
+        "vuetify": "^2.6.12"
     }
 }

--- a/public/markdown-test.md
+++ b/public/markdown-test.md
@@ -1,0 +1,32 @@
+# Languages
+
+In LinguaCafe all the data are separated by the selected language. This means that any action you take in one language will not affect the data in other languages, so the first thing you should do in LinguaCafe is select your target language. You can change your selected language by clicking on the flag in the bottom left corner.
+
+When you import text, LinguaCafe does:
+- **Lemma generation:** When you import a text into LinguaCafe, the text processor will automatically assign dictionary form to words for supported languages. For example, it will assign the lemma `to work` to words such as `worked`.
+- **Gender tagging:** In gendered and supported languages, LinguaCafe will prepend nouns with additional information based on the words' gender. 
+
+## Supported Languages
+
+LinguaCafe supports the following languages:
+
+| Flag                                                          | Language  | DeepL   | Lemma generation | Gender tagging | Dictionaries          |
+|:-------------------------------------------------------------:|:---------:|:-------:|:----------------:|:-------------------:|-----------------------|
+| <img src='../public/images/flags/chinese.png' width='25'>   | Chinese   | &check; |                  |                     | wiktionary, cc-cedict |
+| <img src='../public/images/flags/czech.png' width='25'>     | Czech     | &check; |                  |                     | wiktionary, dict cc   |
+| <img src='../public/images/flags/dutch.png' width='25'>     | Dutch     | &check; | &check;          |                     | dict cc               |
+| <img src='../public/images/flags/finnish.png' width='25'>   | Finnish   | &check; | inaccurate       |                     | wiktionary, dict cc   |
+| <img src='../public/images/flags/french.png' width='25'>    | French    | &check; | &check;          |                     | wiktionary, dict cc   |
+| <img src='../public/images/flags/german.png' width='25'>    | German    | &check; | &check;          | &check;             | wiktionary, dict cc   |
+| <img src='../public/images/flags/italian.png' width='25'>   | Italian   | &check; | &check;          |                     | wiktionary, dict cc   |
+| <img src='../public/images/flags/japanese.png' width='25'>  | Japanese  | &check; | &check;          |                     | jmdict, wiktionary    |
+| <img src='../public/images/flags/korean.png' width='25'>    | Korean    | &check; | &check;          |                     | wiktionary, kengdic   |
+| <img src='../public/images/flags/norwegian.png' width='25'> | Norwegian | &check; | &check;          | &check;             | wiktionary, dict cc   |
+| <img src='../public/images/flags/russian.png' width='25'>   | Russian   | &check; | &check;          |                     | wiktionary, dict cc   |
+| <img src='../public/images/flags/spanish.png' width='25'>   | Spanish   | &check; | &check;          |                     | wiktionary, dict cc   |
+| <img src='../public/images/flags/swedish.png' width='25'>   | Swedish   | &check; | &check;          |                     | dict cc               |
+| <img src='../public/images/flags/ukrainian.png' width='25'> | Ukrainian | &check; |                  |                     | wiktionary            |
+| <img src='../public/images/flags/welsh.png' width='25'>     | Welsh     |         |                  |                     | wiktionary, eurfa     |
+
+> [!NOTE]  
+> Chinese: Mandarin language with simplified Chinese characters.

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -8,6 +8,21 @@ var VueCookie = require('vue-cookie');
 window.Vue.use(VueCookie);
 window.Vue.use(VueRouter);
 
+// vue showdown
+import VueShowdown from 'vue-showdown'
+import MarkdownTest from './components/MarkdownTest.vue';
+
+Vue.use(VueShowdown, {
+    // set default flavor of showdown
+    flavor: 'github',
+    // set default options of showdown (will override the flavor options)
+    options: {
+      emoji: false,
+    },
+  })
+  
+Vue.component('markdown-test', MarkdownTest);
+
 // layout
 import Layout from './components/Layout.vue';
 Vue.component('layout', Layout);
@@ -174,6 +189,7 @@ const router = new VueRouter({
     routes: [
         { path: '/dev', component: DevelopmentTools },
         { path: '/', component: Home },
+        { path: '/markdown-test', component: MarkdownTest },
         { path: '/user-manual/:currentPage?', component: UserManual },
         { path: '/patch-notes', component: PatchNotes },
         { path: '/attributions', component: Attributions },

--- a/resources/js/components/MarkdownTest.vue
+++ b/resources/js/components/MarkdownTest.vue
@@ -1,0 +1,28 @@
+<template>
+        <vue-showdown
+            v-if="markdownText.length"
+            :markdown="markdownText"
+            flavor="github"
+            :options="{ ghCodeBlocks: true, ellipsis: true, emoji: true, tables: true}"
+        ></vue-showdown>
+</template>
+
+<script>
+export default {
+    props: {
+    },
+    data: function() {
+        return {
+            markdownText: '',
+        };
+    },
+    mounted: function() {
+        axios.get('/markdown-test.md').then((response) => {
+            this.markdownText = response.data;
+        });
+    },
+    methods: {
+        
+    }
+}
+</script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,8 @@ Route::group(['middleware' => 'web'], function () {
 });
 
 Route::group(['middleware' => ['auth', 'web']], function () {
+    Route::get ('/users/get', [App\Http\Controllers\UserController::class, 'getUsers']);
+
     // users
     Route::get ('/users/get', [App\Http\Controllers\UserController::class, 'getUsers']);
     Route::post('/users/update', [App\Http\Controllers\UserController::class, 'updateUser']);
@@ -40,6 +42,7 @@ Route::group(['middleware' => ['auth', 'web']], function () {
     Route::post('/jellyfin/process-subtitles', [App\Http\Controllers\MediaPlayerController::class, 'processJellyfinSubtitle']);
 
     // vue routes
+    Route::get('/markdown-test', [App\Http\Controllers\HomeController::class, 'index']);
     Route::get('/dev', [App\Http\Controllers\HomeController::class, 'index']);
     Route::get('/', [App\Http\Controllers\HomeController::class, 'index']);
     Route::get('/user-manual/{currentPage?}', [App\Http\Controllers\HomeController::class, 'index']);


### PR DESCRIPTION
At the moment, the documentation for end users is spread over the site, the README, and the web app itself. This is an attempt to consolidate this documentation into a single place that would facilitate collaboration and make it easy to keep the docs up to date. I think using Markdown is a nice solution for this since it's easy to write, easy to preview, and it's quite portable.

I'm submitting this PR to start a discussion about LinguaCafe's manual, not necessarily with the end goal of merging it. Although I created the `manual` folder, I think [Github's Wikis](https://docs.github.com/en/communities/documenting-your-project-with-wikis/about-wikis) might be the most frictionless solution here. With this PR, I'd like to know if you think this adds value to the project and it's worth pursuing. I'm open to ideas and suggestions.

- **Branch:** https://github.com/uzluisf/LinguaCafe/tree/linguacafe-manual
- **Manual:** https://github.com/uzluisf/LinguaCafe/tree/linguacafe-manual/manual
