### PR TITLE
[Chore] Remove example_sentence column from table

### DIFF
--- a/database/migrations/2021_08_12_122344_create_encountered_words_table.php
+++ b/database/migrations/2021_08_12_122344_create_encountered_words_table.php
@@ -22,7 +22,6 @@ class CreateEncounteredWordsTable extends Migration
             $table->string('kanji');
             $table->string('reading');
             $table->text('translation');
-            $table->text('example_sentence');
             $table->timestamps();
 
             //stage


### PR DESCRIPTION

## Description

Remove `example_sentence` column from the `encountered_words` table since it already exists in the `example_sentences` table.


Related: #22 


## Testing

1. Rebuild Docker image.

```
chmod -R 777 ./ && docker compose -f ./docker-compose-dev-macos.yml build && docker compose -f ./docker-compose-dev-macos.yml up -d --force-recreate
```

2. Run the local server.

```
docker exec -ti linguacafe-webserver-dev npm run watch-poll
```

3. Log into LinguaCafe at http://localhost:3000/.

