### PR TITLE
Thai and Turkish support for the Python side

### DIFF
--- a/docker/PythonDockerfile
+++ b/docker/PythonDockerfile
@@ -5,6 +5,7 @@ RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
         python3 \
         pip \
+        tzdata \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tools/tokenizer.py
+++ b/tools/tokenizer.py
@@ -499,6 +499,8 @@ model_url: dict[str, str] = {
     "russian": "https://github.com/explosion/spacy-models/releases/download/ru_core_news_sm-3.7.0/ru_core_news_sm-3.7.0-py3-none-any.whl",
     "ukrainian": "https://github.com/explosion/spacy-models/releases/download/uk_core_news_sm-3.7.0/uk_core_news_sm-3.7.0-py3-none-any.whl",
     "chinese": "https://github.com/explosion/spacy-models/releases/download/zh_core_web_sm-3.7.0/zh_core_web_sm-3.7.0-py3-none-any.whl",
+    "turkish": "https://huggingface.co/turkish-nlp-suite/tr_core_news_md/resolve/main/tr_core_news_md-any-py3-none-any.whl",
+    "thai": "spacy_thai",
 }
 
 model_name: dict[str, str] = {
@@ -507,6 +509,8 @@ model_name: dict[str, str] = {
     "ru-core-news-sm": "russian",
     "uk-core-news-sm": "ukrainian",
     "zh-core-web-sm": "chinese",
+    "tr-core-news-md": "turkish",
+    "spacy-thai": "thai",
 }
 
 

--- a/tools/tokenizer.py
+++ b/tools/tokenizer.py
@@ -41,6 +41,8 @@ ukrainian_nlp = None
 russian_nlp = None
 greek_nlp = None
 english_nlp = None
+thai_nlp = None
+turkish_nlp = None
 
 @Language.component("custom_sentence_splitter")
 def custom_sentence_splitter(doc):    
@@ -161,6 +163,21 @@ def getTokenizerDoc(language, words):
             greek_nlp = spacy.load("el_core_news_sm", disable = ['ner', 'parser'])
             greek_nlp.add_pipe("custom_sentence_splitter", first=True)
         doc = greek_nlp(words)
+
+    if language == 'thai':
+        global thai_nlp
+        if thai_nlp is None:
+            import spacy_thai
+            thai_nlp = spacy_thai.load()
+            thai_nlp.add_pipe("custom_sentence_splitter", first=True)
+        doc = thai_nlp(words)
+
+    if language == 'turkish':
+        global turkish_nlp
+        if turkish_nlp is None:
+            turkish_nlp = spacy.load("tr_core_news_md", disable = ['ner', 'parser'])
+            turkish_nlp.add_pipe("custom_sentence_splitter", first=True)
+        doc = turkish_nlp(words)
 
     if language in ('welsh', 'czech', 'latin'):
         global multi_nlp


### PR DESCRIPTION
This PR consist of two separate commits so that they could be split into separate PRs in case there is trouble with one of them.

The first commit adds support to locally install the Spacy models for Thai and Turkish, of which I picked the smallest models available that had been maintained on the last year. Tagalog was excluded because the wheel provided has issues when trying to install it so it will be addressed later on. The only Vietnamese model I found [does not work with current versions of Spacy](https://github.com/trungtv/vi_spacy/issues/10) so even if I got it installed it wouldn't load.

The second commit adds the Python side of actually loading and using the models. I tested it by sending the raw text and the language as JSON to the `/tokenizer` route and I successfully got a JSON array with what I think is the tokenized text. I'm still not completely familiar with this part so there could be issues I did not find on my testing.