### PR TITLE
feat: remove version and migrate to named volume for shared folder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 name: linguacafe
 
 networks:
@@ -13,7 +12,7 @@ services:
         depends_on:
             - mysql
         volumes:
-            - ./storage:/var/www/html/storage
+            - storage:/var/www/html/storage
         environment:
             DB_DATABASE: ${DB_DATABASE:-linguacafe}
             DB_USERNAME: ${DB_USERNAME:-linguacafe}
@@ -49,7 +48,15 @@ services:
         environment:
             PYTHONPATH: "/var/www/html/storage/app/model"
         volumes:
-            - ./storage:/var/www/html/storage
+            - storage:/var/www/html/storage
         networks:
             - linguacafe
         platform: ${PLATFORM:-}
+
+volumes:
+  storage:
+    driver: local
+    driver_opts:
+      type: 'none'
+      o: 'bind'
+      device: ${STORAGE_FOLDER:-./storage}


### PR DESCRIPTION
This commit moves from using simple mounts to using a named volume, which copies the contents present at the location in the container into the bound location so that now an empty folder is all that is needed for the deployment. No subfolders needed so that cloning a branch of the repo is optional.

An option to bind the volume to a different location was also added for those users wanting the extra flexibility.

This commit also removes the 'version' section from the compose file since it exists only for backwards compatibility with the V1 of the compose specification which was superseeded 6 years ago.