### PR TITLE
RFC: Use stanza model for Finnish

### DIFF
--- a/docker/PythonDockerfileDev
+++ b/docker/PythonDockerfileDev
@@ -8,6 +8,8 @@ RUN apt-get update -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+RUN pip install torch --index-url https://download.pytorch.org/whl/cpu
+
 RUN pip install -U --no-cache-dir \
         setuptools \
         wheel \
@@ -22,6 +24,8 @@ RUN pip install -U --no-cache-dir \
         bottle \
 #spacy
         spacy \
+#stanza integration for spacy
+        stanza \
 #chinese reading
         pinyin \
 #subtitle file parser
@@ -33,7 +37,6 @@ RUN python3 -m spacy download de_core_news_sm \
     && python3 -m spacy download nb_core_news_sm \
     && python3 -m spacy download es_core_news_sm \
     && python3 -m spacy download nl_core_news_sm \
-    && python3 -m spacy download fi_core_news_sm \
     && python3 -m spacy download fr_core_news_sm \
     && python3 -m spacy download it_core_news_sm \
     && python3 -m spacy download sv_core_news_sm \
@@ -48,5 +51,6 @@ RUN python3 -m spacy download de_core_news_sm \
     && python3 -m spacy download pt_core_news_sm \
     && python3 -m spacy download ro_core_news_sm \
     && python3 -m spacy download sl_core_news_sm \
-    && python3 -m spacy download xx_ent_wiki_sm
+    && python3 -m spacy download xx_ent_wiki_sm \
+    && python3 -c 'import stanza; stanza.download("fi", processors="tokenize,mwt,lemma")'
 

--- a/tools/tokenizer.py
+++ b/tools/tokenizer.py
@@ -22,6 +22,7 @@ import importlib
 import shutil
 import subprocess
 from newspaper import Article
+import spacy_stanza
 
 # create emtpy sapce models
 multi_nlp = None
@@ -122,7 +123,7 @@ def getTokenizerDoc(language, words):
     if language == 'finnish':
         global finnish_nlp
         if finnish_nlp == None:
-            finnish_nlp = spacy.load("fi_core_news_sm", disable = ['ner', 'parser'])
+            finnish_nlp = spacy_stanza.load_pipeline("fi", processors="tokenize,lemma")
             finnish_nlp.add_pipe("custom_sentence_splitter", first=True)
         doc = finnish_nlp(words)
     


### PR DESCRIPTION
This PR is a request for comments about using stanza model for Finnish and is not meant to be merged in current state, hence it is draft.

Unfortunately, Finnish lemmatization is not very accurate. I ran slightly updated benchmark: https://github.com/aajanki/finnish-pos-accuracy and found that spacy lemmatization model used in LinguaCafe has `F1=0.842`, whereas default stanza model for Finnish gives `F1=0.958`.

I tried to use stanza with https://github.com/explosion/spacy-stanza adapter (see PR code). It works. Also, code changes are generalizable to other languages (stanza supports over 70 languages).

There is a huge downside though: the size of resulting docker image, which is mostly because NVIDIA drivers I guess, which are automatically downloaded with pytorch installation.
```
$ podman system df -v  # before
REPOSITORY                                      TAG                       IMAGE ID      CREATED        SIZE        SHARED SIZE  UNIQUE SIZE  CONTAINERS
...
localhost/linguacafedev_python                  latest                    85a508ecb0cb  54 minutes  1.095GB     424.3MB      671.1MB      0
...
$ podman system df -v  # after
REPOSITORY                                      TAG                       IMAGE ID      CREATED        SIZE        SHARED SIZE  UNIQUE SIZE  CONTAINERS
...
localhost/linguacafedev_python                  latest                    2c95c59fdae3  26 minutes  6.906GB     5.53GB       1.376GB      0
...
```

In conclusion, it is possible to significantly increase accuracy for Finnish (and probably some other languages) while not increasing code complexity at the cost of image size.

What do you think about Finnish lemmatization accuracy and introducing stanza?

![lemma_f1_speed](https://github.com/simjanos-dev/LinguaCafe/assets/3449635/ca8cbd42-6a48-46b5-907d-1ebe736df7aa)

Before (lemma is whole word – incorrect):
![Screenshot_20240510_163709](https://github.com/simjanos-dev/LinguaCafe/assets/3449635/b42f1c2a-bd4b-4ea9-849c-424eb1bed279)

After (lemma is correct):
![Screenshot_20240510_165630](https://github.com/simjanos-dev/LinguaCafe/assets/3449635/7da5dee1-8cae-4af0-a348-8dd2aa6eb0b2)