### PR TITLE
Fix spacing in TTS for phrases

### DIFF
--- a/resources/js/components/Text/TextBlockGroup.vue
+++ b/resources/js/components/Text/TextBlockGroup.vue
@@ -452,11 +452,11 @@
                     var text = '';
 
                     this.vocabBox.phrase.forEach((phraseWord, index) => {
-                        text += phraseWord.word;
-
                         if (index) {
                             text += ' ';
                         }
+
+                        text += phraseWord.word;
                     });
                 }
 


### PR DESCRIPTION
Previously, first two words in phrase were joined and there was a space after the phrase: `Säpsähdän hereille` became `Säpsähdänhereille ` which resulted in mispronunciation. This change fixes the resulting `text` to the correct one.
