### PR TITLE
fix: only clear timeout if the ongoingSelection is not empty

### DIFF
--- a/resources/js/components/Text/TextBlockGroup.vue
+++ b/resources/js/components/Text/TextBlockGroup.vue
@@ -516,13 +516,13 @@
                 if (this.ongoingSelection.length) {
                     event.preventDefault();
                 }
-                
-                if (this.touchTimer) {
+
+                if (this.touchTimer && this.ongoingSelection.length) {
                     clearTimeout(this.touchTimer);
                     this.touchTimer = null;
                     return;
                 }
-                
+
                 var touch = event.changedTouches[0];
                 var element = document.elementFromPoint( touch.clientX, touch.clientY );
 


### PR DESCRIPTION
Closes: #262 

Sorry for another one line PR.

It seems that for Apple Pencil touch events the updateSelectionTouchEvent function is called right away after the startSelectionTouchEvent, meaning that the function inside the touchTimer setTimeout never executes due to clearTimeout.
This leaves the ongoingSelection array empty meaning that the updateSelection is never called due to this if:

```js
   if (wordIndex !== null && this.ongoingSelection.length) {
      this.updateSelection(wordIndex);
   }
``` 

This PR fixes it by only calling the clearTimeout if the this.touchTimer exists and the ongoingSelection is not empty

