### PR TITLE
Feature: Add condition to depends_on and healthcheck for mysql

### DIFF
--- a/docker-compose-dev-macos.yml
+++ b/docker-compose-dev-macos.yml
@@ -13,7 +13,8 @@ services:
             context: .
             dockerfile: ./docker/PhpDockerfileDev
         depends_on:
-            - mysql
+            mysql:
+                condition: service_healthy
         volumes:
             - ./:/var/www/html
             - ./docker/vhost.conf:/etc/apache2/sites-available/000-default.conf
@@ -36,6 +37,11 @@ services:
         container_name: linguacafe-database-dev
         restart: unless-stopped
         tty: true
+        healthcheck:
+            test: ["CMD", 'mysqladmin', 'ping', '-h', 'localhost', '-u', 'root', '-p$MYSQL_ROOT_PASSWORD']
+            interval: 5s
+            timeout: 5s
+            retries: 10
         ports:
           - "3308:3306"
         volumes:
@@ -49,11 +55,11 @@ services:
         networks:
             - linguacafedev
     python:
-        container_name: linguacafe-python-service-dev 
+        container_name: linguacafe-python-service-dev
         command: "python3 /app/tokenizer.py"
         restart: unless-stopped
         tty: true
-        ports: 
+        ports:
             - "8678:8678"
         build:
             dockerfile: ./docker/PythonDockerfileDev

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -13,7 +13,8 @@ services:
             context: .
             dockerfile: ./docker/PhpDockerfileDev
         depends_on:
-            - mysql
+            mysql:
+                condition: service_healthy
         volumes:
             - ./:/var/www/html
             - ./docker/vhost.conf:/etc/apache2/sites-available/000-default.conf
@@ -36,6 +37,11 @@ services:
         container_name: linguacafe-database-dev
         restart: unless-stopped
         tty: true
+        healthcheck:
+            test: ["CMD", 'mysqladmin', 'ping', '-h', 'localhost', '-u', 'root', '-p$MYSQL_ROOT_PASSWORD']
+            interval: 5s
+            timeout: 5s
+            retries: 10
         ports:
           - "3308:3306"
         volumes:
@@ -49,11 +55,11 @@ services:
         networks:
             - linguacafedev
     python:
-        container_name: linguacafe-python-service-dev 
+        container_name: linguacafe-python-service-dev
         command: "python3 /app/tokenizer.py"
         restart: unless-stopped
         tty: true
-        ports: 
+        ports:
             - "8678:8678"
         build:
             dockerfile: ./docker/PythonDockerfileDev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,8 @@ services:
         container_name: linguacafe-webserver
         restart: unless-stopped
         depends_on:
-            - mysql
+            mysql:
+                condition: service_healthy
         volumes:
             - ./storage:/var/www/html/storage
         environment:
@@ -30,6 +31,11 @@ services:
         container_name: linguacafe-database
         restart: unless-stopped
         tty: true
+        healthcheck:
+            test: ["CMD", 'mysqladmin', 'ping', '-h', 'localhost', '-u', 'root', '-p$MYSQL_ROOT_PASSWORD']
+            interval: 10s
+            timeout: 5s
+            retries: 10
         volumes:
             - ./database:/var/lib/mysql
         environment:


### PR DESCRIPTION
By default the depends_on condition only guarantees that the "mysql" container will be built before the "webserver" container. This PR adds an health check and condition to the "mysql" container that makes sure that the "webserver" will be started only after the mysql database is ready to allow incoming connections.