### PR TITLE
Streamline the build and use of the Python image

### DIFF
--- a/docker-compose-dev-macos.yml
+++ b/docker-compose-dev-macos.yml
@@ -1,4 +1,3 @@
-version: '3'
 name: linguacafedev
 
 networks:
@@ -56,7 +55,6 @@ services:
             - linguacafedev
     python:
         container_name: linguacafe-python-service-dev
-        command: "python3 /app/tokenizer.py"
         restart: unless-stopped
         tty: true
         ports:
@@ -68,6 +66,4 @@ services:
             - ./storage/app:/var/www/html/storage/app
         networks:
             - linguacafedev
-        environment:
-            PYTHONPATH: "/var/www/html/storage/app/model"
         platform: linux/amd64

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,4 +1,3 @@
-version: '3'
 name: linguacafedev
 
 networks:
@@ -56,7 +55,6 @@ services:
             - linguacafedev
     python:
         container_name: linguacafe-python-service-dev
-        command: "python3 /app/tokenizer.py"
         restart: unless-stopped
         tty: true
         ports:
@@ -68,5 +66,3 @@ services:
             - ./storage/app:/var/www/html/storage/app
         networks:
             - linguacafedev
-        environment:
-            PYTHONPATH: "/var/www/html/storage/app/model"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,12 +49,9 @@ services:
             - linguacafe
     python:
         container_name: linguacafe-python-service
-        command: "python3 /app/tokenizer.py"
         restart: unless-stopped
         tty: true
         image: ghcr.io/simjanos-dev/linguacafe-python-service:${VERSION:-latest}
-        environment:
-            PYTHONPATH: "/var/www/html/storage/app/model"
         volumes:
             - ./storage:/var/www/html/storage
         networks:

--- a/docker/PythonDockerfile
+++ b/docker/PythonDockerfile
@@ -1,17 +1,12 @@
-FROM ubuntu:22.04
+FROM python:slim
 
 WORKDIR /app
-RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends \
-        python3 \
-        pip \
-        tzdata \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
 
 RUN addgroup --gid 1000 laravel \
     && adduser --ingroup laravel --disabled-password --gecos "" --shell /bin/sh laravel
 USER laravel
+
+ENV PYTHONPATH="/var/www/html/storage/app/model"
 
 RUN pip install -U --no-cache-dir \
         setuptools \
@@ -57,4 +52,4 @@ RUN python3 -m spacy download de_core_news_sm \
 
 COPY ./tools /app
 
-CMD [ "export PYTHONPATH=\"${HOME}/.local/bin:${PYTHONPATH}\"" ]
+CMD [ "python", "/app/tokenizer.py" ]

--- a/docker/PythonDockerfileDev
+++ b/docker/PythonDockerfileDev
@@ -1,16 +1,12 @@
-FROM ubuntu:22.04
+FROM python:slim
 
 WORKDIR /app
-RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends \
-        python3 \
-        pip \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
 
 RUN addgroup --gid 1000 laravel \
     && adduser --ingroup laravel --disabled-password --gecos "" --shell /bin/sh laravel
 USER laravel
+
+ENV PYTHONPATH="/var/www/html/storage/app/model"
 
 RUN pip install -U --no-cache-dir \
         setuptools \
@@ -55,4 +51,4 @@ RUN python3 -m spacy download de_core_news_sm \
     && python3 -m spacy download xx_ent_wiki_sm
 
 
-CMD [ "export PYTHONPATH=\"${HOME}/.local/bin:${PYTHONPATH}\"" ]
+CMD [ "python", "/app/tokenizer.py" ]

--- a/tools/tokenizer.py
+++ b/tools/tokenizer.py
@@ -381,12 +381,12 @@ def loadBook(file, sortMethod):
     items = list(book.get_items())
 
     # select sorting method for chapters
-    if sortMethod == 'default':
-        sortedItems = items
-    elif sortMethod == 'spine':
+    if sortMethod == 'spine':
         sortedItems = list()
         for item in enumerate(book.spine):
             sortedItems.append(book.get_item_with_id(item[1][0]))
+    else:
+        sortedItems = items
 
     for item in sortedItems:
         if item.get_type() == ebooklib.ITEM_DOCUMENT:


### PR DESCRIPTION
The first commit performs a series of very small refactors that I think make sense, such as moving the non configurable settings from the composefile to the image itself, and using a python base image instead of an ubuntu one just to install python on it immediately.

The second commit "fixes" a bug I encountered when testing the import book functionality where `sortedItems` would not be defined, most likely because `sortMethod` was neither of the options checked, which raised an exception when trying to access it later.

I made it so that it gets the default behaviour whenever the "spine" option is **not** selected, and isolated it on its own commit so it can be easily left out if you'd rather address the issue by different means.