### PR TITLE
remove git requirement, use curl for download docker compose

### DIFF
--- a/install_linguacafe.bat
+++ b/install_linguacafe.bat
@@ -1,14 +1,6 @@
 @echo off
 setlocal EnableDelayedExpansion
 
-REM Check if git is installed
-git --version >nul 2>&1
-if %errorlevel% neq 0 (
-    echo Git is not installed. Please install Git and try again.
-    timeout /t 10 >nul
-    exit /b 1
-)
-
 REM Check if Docker is installed
 docker --version >nul 2>&1
 if %errorlevel% neq 0 (
@@ -29,7 +21,7 @@ REM If the folder already exists, update and close
 if exist linguacafe (
     echo Installation of LingaCafe detected, updating...
     cd linguacafe
-    git pull
+    curl -O https://raw.githubusercontent.com/simjanos-dev/LinguaCafe/main/docker-compose.yml
     docker-compose pull
     docker-compose up -d --force-recreate
     timeout /t 10 >nul
@@ -46,9 +38,17 @@ set /p confirm_installation=Do you want to proceed with the installation? (Y/N):
 REM Check user's response
 if /i "!confirm_installation!"=="Y" (
     echo Proceeding with installation...
-    REM Clone repository or update if folder exists
-    git clone -b deploy https://github.com/simjanos-dev/LinguaCafe.git linguacafe
+    
+    REM Create directory if it doesn't exist and change to that directory
+    if not exist linguacafe (
+        mkdir linguacafe
+        mkdir linguacafe/storage
+    )
     cd linguacafe
+    
+    REM Download docker-compose.yml from the main branch
+    curl -O https://raw.githubusercontent.com/simjanos-dev/LinguaCafe/main/docker-compose.yml
+    
     docker-compose up -d
 
     echo Your LinguaCafe server has started, you can soon open it in your browser on this url: http://localhost:9191. Sometimes this can take a few minutes on slower computers.
@@ -57,6 +57,7 @@ if /i "!confirm_installation!"=="Y" (
     echo Installation canceled. Exiting...
     exit /b 1
 )
+
 
 :end
 endlocal


### PR DESCRIPTION
Update install script to close #258 

Remove git requirement, add storage folder at first install.

Use curl, which is installed since Windows 10, if we want to support install on Windows 7/8 I could rewrite the script to use a call to powershell instead, but i don't have machines to test it...