### PR TITLE
fix: revert to setting PYTHONPATH on the composefile for dev

### DIFF
--- a/docker-compose-dev-macos.yml
+++ b/docker-compose-dev-macos.yml
@@ -66,4 +66,6 @@ services:
             - ./storage/app:/var/www/html/storage/app
         networks:
             - linguacafedev
+        environment:
+            PYTHONPATH: "/var/www/html/storage/app/model"
         platform: linux/amd64

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -66,3 +66,5 @@ services:
             - ./storage/app:/var/www/html/storage/app
         networks:
             - linguacafedev
+        environment:
+            PYTHONPATH: "/var/www/html/storage/app/model"

--- a/docker/PythonDockerfileDev
+++ b/docker/PythonDockerfileDev
@@ -6,8 +6,6 @@ RUN addgroup --gid 1000 laravel \
     && adduser --ingroup laravel --disabled-password --gecos "" --shell /bin/sh laravel
 USER laravel
 
-ENV PYTHONPATH="/var/www/html/storage/app/model"
-
 RUN pip install -U --no-cache-dir \
         setuptools \
         wheel \


### PR DESCRIPTION
This commit reverts the process of setting the PYTHONPATH on the dev environment to being done on the composefile instead of doing it during the build process.