### PR TITLE
feat: added new action to build a beta image

### DIFF
--- a/.github/workflows/beta-image.yml
+++ b/.github/workflows/beta-image.yml
@@ -1,0 +1,91 @@
+name: Build beta image
+
+on:
+  workflow_dispatch
+
+env:
+  REGISTRY: ghcr.io
+  # IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  # define the job to build and publish docker images
+  build-and-push-docker-images:
+    runs-on: ubuntu-latest
+
+    # steps to perform in the job
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      # set up Docker build action
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Get build date
+        id: get_date
+        run: echo "BUILD_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+      # https://github.com/docker/metadata-action
+      - name: Docker PHP meta
+        id: meta_php
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.actor }}/linguacafe-webserver
+          tags: |
+            type=ref,event=branch
+            type=ref,suffix=-${{ env.BUILD_DATE}},event=branch
+
+      # https://github.com/docker/metadata-action
+      - name: Docker Python meta
+        id: meta_python
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.actor }}/linguacafe-python-service
+          tags: |
+            type=ref,event=branch
+            type=ref,suffix=-${{ env.BUILD_DATE}},event=branch
+
+      # https://github.com/docker/login-action#github-container-registry
+      - name: Log in to Github Packages
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_LINGUA_PAT }}
+
+      # https://github.com/docker/build-push-action
+      - name: Build and push PHP image to GitHub Container Registry
+        id: docker_build_php
+        uses: docker/build-push-action@v3
+        with:
+          file: "./docker/PhpDockerfile"
+          # extra platforms can be added here:
+          platforms: |
+            linux/amd64
+            linux/arm64
+          # Note: tags have to be all lower-case
+          tags: ${{ steps.meta_php.outputs.tags }}
+          labels: ${{ steps.meta_php.outputs.labels }}
+          push: true
+
+      - name: PHP Image digest
+        run: echo ${{ steps.docker_build_php.outputs.digest }}
+
+      # https://github.com/docker/build-push-action
+      - name: Build and push Python image to GitHub Container Registry
+        id: docker_build_python
+        uses: docker/build-push-action@v3
+        with:
+          file: "./docker/PythonDockerfile"
+          platforms: |
+            linux/amd64
+          # Note: tags have to be all lower-case
+          tags: ${{ steps.meta_python.outputs.tags }}
+          labels: ${{ steps.meta_python.outputs.labels }}
+          push: true
+
+      - name: Python Image digest
+        run: echo ${{ steps.docker_build_python.outputs.digest }}
+


### PR DESCRIPTION
This action can be manually launched from any branch but it really should only ever be used from the `beta` one.

It tags the image with `${branch_name}` and with `${branch_name}-YYYY-MM-DD` so that it is possible to both get the latest beta image with a simple pull and to pin a version with accuracy of a day; if an image is rebuilt within the same day it will be overwritten.

This needs to be merged into `main` for it to be visible in the *Actions* tab, but i'm not really sure if it has to be copied over to the `beta` branch too.