### PR TITLE
fix: language default fonts

### DIFF
--- a/database/seeders/FontTypeSeeder.php
+++ b/database/seeders/FontTypeSeeder.php
@@ -12,25 +12,20 @@ class FontTypeSeeder extends Seeder
     {
         // Noto sans JP
         $notoSansJpLanguages = [
-            'Croatian',
             'Danish',
-            'Czech',
             'Dutch',
             'English',
             'Finnish',
             'French',
             'German',
-            'Greek',
             'Italian',
             'Japanese',
             'Korean',
             'Latin',
-            'Macedonian',
             'Norwegian',
             'Portuguese',
             'Romanian',
             'Russian',
-            'Slovenian',
             'Spanish',
             'Swedish',
             'Thai',
@@ -77,8 +72,13 @@ class FontTypeSeeder extends Seeder
         }
 
         // OpenSans
-        $poltawskiNowLanguages = [
+        $openSansLanguages = [
+            'Croatian',
+            'Czech',
+            'Greek',
+            'Macedonian',
             'Polish',
+            'Slovenian',
         ];
 
         $fontType = FontType
@@ -86,13 +86,13 @@ class FontTypeSeeder extends Seeder
             ->first();
 
         if ($fontType) {
-            $fontType->languages = json_encode($poltawskiNowLanguages);
+            $fontType->languages = json_encode($openSansLanguages);
             $fontType->save();
         } else {
             $fontType = new FontType();
             $fontType->name = 'OpenSans';
             $fontType->filename = 'DefaultOpenSans.ttf';
-            $fontType->languages = json_encode($poltawskiNowLanguages);
+            $fontType->languages = json_encode($openSansLanguages);
             $fontType->default = true;
             $fontType->save();
         }


### PR DESCRIPTION
The default font "NotoSans JP" does not render some diacritics very well, in particular, the háček used in several Slavic languages and the acute accent in Greek. The effected languages: Croatian, Czech, Greek, Macedonian, and Slovenian have all been transferred to the "OpenSans" default font group which renders the mentioned diacritics properly.

## Font Comparison
| NotoSans JP | OpenSans |
| ----------- | -------- |
|![croatian_noto_jp](https://github.com/user-attachments/assets/eec321a0-60ca-4842-ad40-b74d552573ba)|![croatian_open_sans](https://github.com/user-attachments/assets/7895ab09-5981-49c7-ac42-c650134abcd1)
|![czech_noto_jp](https://github.com/user-attachments/assets/63d5cbd4-f4cd-4038-8c71-544d1df36e91)|![czech_open_sans](https://github.com/user-attachments/assets/a6400b97-7b82-4d0a-b929-2d61979349fe)
|![greek_noto_jp](https://github.com/user-attachments/assets/0b963224-4e29-4c64-a36a-96fc92a05c2d)|![greek_open_sans](https://github.com/user-attachments/assets/f07aa9f7-45d7-4eb3-a493-1a80f3ff67b9)
|![macedonian_noto_jp](https://github.com/user-attachments/assets/21408c51-f221-45aa-895f-8040baf92117)|![macedonian_open_sans](https://github.com/user-attachments/assets/3059ce8c-c1b6-4dfa-9147-c11797969453)
|![slovenian_noto_jp](https://github.com/user-attachments/assets/3f2c2f08-c905-4448-b4cb-9790e90da218)|![slovenian_open_sans](https://github.com/user-attachments/assets/801fdc3e-f7ca-4618-a1a8-1be7986c16d7)
