### PR TITLE
Fix glossary item colors in light mode

### DIFF
--- a/resources/sass/DarkMode.scss
+++ b/resources/sass/DarkMode.scss
@@ -361,48 +361,6 @@
     }
 }
 
-#app.dark #text-reader-glossary .glossary-entry {
-    &:nth-child(even) {
-        background-color: var(--v-gray-base);
-    }
-
-    .stage {
-        &[stage="-7"] {
-            background-color: var(--v-highlightedWordLevel7-base);
-            color: var(--v-textDark-base);
-        }
-        &[stage="-6"] {
-            background-color: var(--v-highlightedWordLevel6-base);
-            color: var(--v-textDark-base);
-        }
-        &[stage="-5"] {
-            background-color: var(--v-highlightedWordLevel5-base);
-            color: var(--v-textDark-base);
-        }
-        &[stage="-4"] {
-            background-color: var(--v-highlightedWordLevel4-base);
-            color: var(--v-textDark-base);
-        }
-        &[stage="-3"] {
-            background-color: var(--v-highlightedWordLevel3-base);
-            color: var(--v-textDark-base);
-        }
-        &[stage="-2"] {
-            background-color: var(--v-highlightedWordLevel2-base);
-            color: var(--v-textDark-base);
-        }
-        &[stage="-1"] {
-            background-color: var(--v-highlightedWordLevel1-base);
-            color: var(--v-textDark-base);
-        }
-
-        &[stage="2"] {
-            background-color: var(--v-newWord-base);
-            color: var(--v-textDark-base);
-        }
-    }
-}
-
 // vocab box active stage button
 #app.dark #vocab-box #vocab-box-stage-buttons .v-btn.v-btn--active, 
 #app.dark #vocab-side-box #vocab-box-stage-buttons .v-btn.v-btn--active,

--- a/resources/sass/TextReader/TextReaderGlossary.scss
+++ b/resources/sass/TextReader/TextReaderGlossary.scss
@@ -6,7 +6,7 @@
     min-height: 100px;
 
     &:nth-child(even) {
-        background-color: rgb(242, 242, 242);
+        background-color: var(--v-gray-base);
     }
 
     rt {
@@ -36,6 +36,35 @@
         &[stage="2"] {
             background-color: var(--v-newWord-base);
             color: var(--v-highlightedWordText-base);
+        }
+
+        &[stage="-7"] {
+            background-color: var(--v-highlightedWordLevel7-base);
+            color: var(--v-textDark-base);
+        }
+        &[stage="-6"] {
+            background-color: var(--v-highlightedWordLevel6-base);
+            color: var(--v-textDark-base);
+        }
+        &[stage="-5"] {
+            background-color: var(--v-highlightedWordLevel5-base);
+            color: var(--v-textDark-base);
+        }
+        &[stage="-4"] {
+            background-color: var(--v-highlightedWordLevel4-base);
+            color: var(--v-textDark-base);
+        }
+        &[stage="-3"] {
+            background-color: var(--v-highlightedWordLevel3-base);
+            color: var(--v-textDark-base);
+        }
+        &[stage="-2"] {
+            background-color: var(--v-highlightedWordLevel2-base);
+            color: var(--v-textDark-base);
+        }
+        &[stage="-1"] {
+            background-color: var(--v-highlightedWordLevel1-base);
+            color: var(--v-textDark-base);
         }
     }
 

--- a/resources/sass/TextReader/TextReaderGlossary.scss
+++ b/resources/sass/TextReader/TextReaderGlossary.scss
@@ -38,33 +38,29 @@
             color: var(--v-highlightedWordText-base);
         }
 
+        &[stage^="-"] {
+            color: var(--v-highlightedWordText-base);
+        }
         &[stage="-7"] {
             background-color: var(--v-highlightedWordLevel7-base);
-            color: var(--v-textDark-base);
         }
         &[stage="-6"] {
             background-color: var(--v-highlightedWordLevel6-base);
-            color: var(--v-textDark-base);
         }
         &[stage="-5"] {
             background-color: var(--v-highlightedWordLevel5-base);
-            color: var(--v-textDark-base);
         }
         &[stage="-4"] {
             background-color: var(--v-highlightedWordLevel4-base);
-            color: var(--v-textDark-base);
         }
         &[stage="-3"] {
             background-color: var(--v-highlightedWordLevel3-base);
-            color: var(--v-textDark-base);
         }
         &[stage="-2"] {
             background-color: var(--v-highlightedWordLevel2-base);
-            color: var(--v-textDark-base);
         }
         &[stage="-1"] {
             background-color: var(--v-highlightedWordLevel1-base);
-            color: var(--v-textDark-base);
         }
     }
 

--- a/resources/sass/TextReader/TextReaderGlossary.scss
+++ b/resources/sass/TextReader/TextReaderGlossary.scss
@@ -5,7 +5,7 @@
     box-sizing: border-box;
     min-height: 100px;
 
-    &:nth-child(even) {
+    &:nth-child(odd) {
         background-color: var(--v-gray-base);
     }
 


### PR DESCRIPTION
This fixes the CSS for issue #244 to properly show the glossary item background colors in all the color modes.

Also, I just wanted to note that it is a bit confusing to have the "New" words display with a "2". It would probably make sense to replace it with an icon or just the word "New", but that should probably be addressed in another issue.


## Light mode
![image](https://github.com/user-attachments/assets/b115b2fb-3d7a-4180-ad54-887fad22c95e)

## Dark mode
![image](https://github.com/user-attachments/assets/a6029893-ff58-4a1d-be76-b186972f6dfc)


## eInk mode
![image](https://github.com/user-attachments/assets/e468c1d7-64af-4cac-b636-5ad14bc44c96)
