### PR TITLE
Add lemma count statistic block

### DIFF
--- a/app/Services/StatisticsService.php
+++ b/app/Services/StatisticsService.php
@@ -7,7 +7,7 @@ use App\Models\GoalAchievement;
 use App\Models\EncounteredWord;
 
 class StatisticsService {
-    
+
     public function __construct() {
     }
 
@@ -37,7 +37,7 @@ class StatisticsService {
             ->where('language', $language)
             ->where('goal_id', $readingGoal->id)
             ->sum('achieved_quantity');
-        
+
         if ($language == 'japanese') {
             // get unique kanji
             $uniqueKanji = [];
@@ -55,13 +55,13 @@ class StatisticsService {
                     }
                 }
             }
-            
+
             $languageStatistics->kanji = new \stdClass();
             $languageStatistics->kanji->name = 'Kanji';
             $languageStatistics->kanji->value = count($uniqueKanji);
             $languageStatistics->kanji->icon = 'mdi-ideogram-cjk';
         }
-        
+
         $languageStatistics->known = new \stdClass();
         $languageStatistics->known->name = 'Known words';
         $languageStatistics->known->icon = 'mdi-credit-card-check';
@@ -80,7 +80,18 @@ class StatisticsService {
             ->where('user_id', $userId)
             ->where('language', $language)
             ->count('id');
-        
+
+        $languageStatistics->knownLemmas = new \stdClass();
+        $languageStatistics->knownLemmas->name = 'Known lemmas';
+        $languageStatistics->knownLemmas->icon = 'mdi-alpha-l-box';
+        $languageStatistics->knownLemmas->value = EncounteredWord
+            ::select('lemma')
+            ->where('stage', 0)
+            ->where('user_id', $userId)
+            ->where('language', $language)
+            ->groupBy('lemma')
+            ->having('lemma', '!=', '')
+            ->get()->count();
         return $languageStatistics;
     }
 }


### PR DESCRIPTION
The new statistic block displays the count of unique lemmas known by the user on the home page. This is helpful for users to get a more accurate picture of their knowns words for a language. Especially for languages which use a lot of declensions.

## Screenshot
![image](https://github.com/user-attachments/assets/47930553-5a4d-479f-9656-59847bd12d5e)


I thought this would be a good addition to the statistics blocks. Let me know if there's anything you'd like me a change.