### PR TITLE
fix: bind punctuation to following word when needed

### DIFF
--- a/app/Services/TextBlockService.php
+++ b/app/Services/TextBlockService.php
@@ -535,18 +535,18 @@ class TextBlockService
                     $wordIndex < $maxWordIndex &&
                     $this->processedWords[$wordIndex + 1]->sentence_index !== $this->processedWords[$wordIndex]->sentence_index
                 );
-            } else {
-                //$word->spaceAfter = !in_array($this->language, $languagesWithoutSpaces, true);
+            } elseif (!isset($word->space_before) && !isset($word->is_punct)) {
+                // Default to legacy hardcoded spaces without punctuation checks
+                $word->spaceAfter = !in_array($this->language, $languagesWithoutSpaces, true);
             }
 
             if ($wordIndex < $maxWordIndex && in_array($this->processedWords[$wordIndex + 1]->word, $tokensWithNoSpaceBefore, true) ||
-                in_array($this->processedWords[$wordIndex]->word, $tokensWithNoSpaceAfter, true) ||
-                isset($word->is_punct) && $word->is_punct && isset($word->space_before) && $word->space_before
+                in_array($this->processedWords[$wordIndex]->word, $tokensWithNoSpaceAfter, true)
             ) {
                 $word->spaceAfter = false;
             }
 
-            if (isset($word->space_after) && $word->space_after) {
+            if (isset($word->is_punct) && isset($word->space_before) && $word->space_after) {
                 $word->spaceAfter = true;
             }
 

--- a/tools/tokenizer.py
+++ b/tools/tokenizer.py
@@ -289,14 +289,18 @@ def tokenizeText(text, language, sentenceIndexStart = 0):
         text = text.replace(' ', ' THAINEWSENTENCE ')
         
     doc = getTokenizerDoc(language, text)
-    
+
     thaiSentenceIndex = 0
+    space_before = False
     for sentenceIndex, sentence in enumerate(doc.sents):
         for token in sentence:
             word = str(token.text)
-            if word == ' ' or word == '' or word == ' ':
+            if word == " " or word == "" or word == " ":
+                space_before = True
                 continue
-            
+            else:
+                space_before = False
+
             # get lemma
             lemma = token.lemma_
             
@@ -335,11 +339,33 @@ def tokenizeText(text, language, sentenceIndexStart = 0):
                 else:
                     if word == 'NEWLINE':
                         thaiSentenceIndex = thaiSentenceIndex + 1
-                        
-                    tokenizedWords.append({'w': word, 'r': reading, 'l': lemma, 'lr': lemmaReading, 'pos': token.pos_,'si': thaiSentenceIndex + sentenceIndexStart, 'g': gender})
-            else:
-                tokenizedWords.append({'w': word, 'r': reading, 'l': lemma, 'lr': lemmaReading, 'pos': token.pos_,'si': sentenceIndex + sentenceIndexStart, 'g': gender})
 
+                    tokenizedWords.append(
+                        {
+                            "w": word,
+                            "r": reading,
+                            "l": lemma,
+                            "lr": lemmaReading,
+                            "pos": token.pos_,
+                            "si": thaiSentenceIndex + sentenceIndexStart,
+                            "g": gender,
+                        }
+                    )
+            else:
+                tokenizedWords.append(
+                    {
+                        "w": word,
+                        "r": reading,
+                        "l": lemma,
+                        "lr": lemmaReading,
+                        "pos": token.pos_,
+                        "si": sentenceIndex + sentenceIndexStart,
+                        "g": gender,
+                        "ip": token.is_punct,
+                        "sb": space_before,
+                        "sa": bool(token.whitespace_),
+                    }
+                )
 
     return tokenizedWords
 

--- a/tools/tokenizer.py
+++ b/tools/tokenizer.py
@@ -349,6 +349,9 @@ def tokenizeText(text, language, sentenceIndexStart = 0):
                             "pos": token.pos_,
                             "si": thaiSentenceIndex + sentenceIndexStart,
                             "g": gender,
+                            "ip": token.is_punct,
+                            "sb": space_before,
+                            "sa": bool(token.whitespace_),
                         }
                     )
             else:


### PR DESCRIPTION
This PR fixes issue #328.

The existing punctuation spacing implementation uses a `spaceAfter` attribute to force a space (right padding) after punctuation from the `tokens_with_no_space_before` config array. However, for many punctuation marks this reduces readability since punctuation (like quotation marks) may appear to be bound to the previous word when it should be bound to the next word.

For example:
> Tommy said, "Hello there".

would be incorrectly rendered like this

> Tommy said," Hello there".

This fix propagates the `is_punct` and `whitespace_` attributes from the spacy tokenization and a boolean (`space_before`) for tokens with preceding whitespace.  They're all used to more accurately arrange the space surrounding punctuation.

@simjanos-dev I made some progress on this, but I've only tested it with German so far. It seems to work well, but I was wondering if you had a particular procedure or some sample texts you used to test? I want to make sure my changes didn't break rendering for the other languages.

## New rendering
![image](https://github.com/user-attachments/assets/c2589185-7559-40e0-97e2-d3f2e638e159)

## Previous rendering
![image](https://github.com/user-attachments/assets/9167dd73-e450-4b46-86de-09560be84333)
