### PR TITLE
Fix migration for modify users table

### DIFF
--- a/database/migrations/2024_06_22_163858_modify_users_table_4.php
+++ b/database/migrations/2024_06_22_163858_modify_users_table_4.php
@@ -17,7 +17,7 @@ class ModifyUsersTable4 extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->string('uuid', 128)->unique();
+            $table->string('uuid', 128)->nullable();
         });
 
         $users = User::all();
@@ -25,6 +25,11 @@ class ModifyUsersTable4 extends Migration
             $user->uuid = Str::uuid()->toString();
             $user->save();
         }
+
+        // Add unique
+        Schema::table('users', function (Blueprint $table) {
+            $table->unique('uuid');
+        });
     }
 
     /**


### PR DESCRIPTION
Fix for migration scheme for table 'users'.
When user is more than one, the migration ends with error:

```
linguacafe-test                 |    INFO  Running migrations.
linguacafe-test                 |
linguacafe-test                 |   0001_01_01_000001_create_cache_table .......................... 69.60ms DONE
linguacafe-test                 |   0001_01_01_000002_create_jobs_table ........................... 75.93ms DONE
linguacafe-test                 |   2024_06_22_163858_modify_users_table_4 ........................ 29.23ms FAIL
linguacafe-test                 |
linguacafe-test                 | In Connection.php line 808:
linguacafe-test                 |
linguacafe-test                 |   SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '' fo
linguacafe-test                 |   r key 'users.users_uuid_unique' (Connection: mysql, SQL: alter table `users
linguacafe-test                 |   ` add unique `users_uuid_unique`(`uuid`))
linguacafe-test                 |
linguacafe-test                 |
linguacafe-test                 | In Connection.php line 571:
linguacafe-test                 |
linguacafe-test                 |   SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '' fo
linguacafe-test                 |   r key 'users.users_uuid_unique'
```
