### PR TITLE
Speed up builds

### DIFF
--- a/.github/workflows/beta-image.yml
+++ b/.github/workflows/beta-image.yml
@@ -10,18 +10,18 @@ env:
 jobs:
   # define the job to build and publish docker images
   build-and-push-docker-images:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # steps to perform in the job
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # set up Docker build action
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Get build date
         id: get_date
@@ -30,7 +30,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Docker PHP meta
         id: meta_php
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ github.actor }}/linguacafe-webserver
           tags: |
@@ -40,7 +40,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Docker Python meta
         id: meta_python
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ github.actor }}/linguacafe-python-service
           tags: |
@@ -49,7 +49,7 @@ jobs:
 
       # https://github.com/docker/login-action#github-container-registry
       - name: Log in to Github Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -58,7 +58,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push PHP image to GitHub Container Registry
         id: docker_build_php
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           file: "./docker/PhpDockerfile"
           # extra platforms can be added here:
@@ -76,7 +76,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Python image to GitHub Container Registry
         id: docker_build_python
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           file: "./docker/PythonDockerfile"
           platforms: |

--- a/.github/workflows/beta-image.yml
+++ b/.github/workflows/beta-image.yml
@@ -57,6 +57,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: "./docker/PhpDockerfile"
+          cache-from: type=gha
+          cache-to: type=gha
           # extra platforms can be added here:
           platforms: |
             linux/amd64
@@ -107,6 +109,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           file: "./docker/PythonDockerfile"
+          cache-from: type=gha
+          cache-to: type=gha
           platforms: |
             linux/amd64
           # Note: tags have to be all lower-case

--- a/.github/workflows/beta-image.yml
+++ b/.github/workflows/beta-image.yml
@@ -8,9 +8,19 @@ env:
   # IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  # define the job to build and publish docker images
-  build-and-push-docker-images:
+  #
+  # capture time at the beginning to ensure consistent tagging
+  capture-date:
     runs-on: ubuntu-22.04
+    steps:
+      - name: Get build date
+        id: get_date
+        run: echo "BUILD_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+  # build images in parallel for a speed increase
+  build-and-push-php-image:
+    runs-on: ubuntu-22.04
+    needs: capture-date
 
     # steps to perform in the job
     steps:
@@ -23,26 +33,12 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Get build date
-        id: get_date
-        run: echo "BUILD_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-
       # https://github.com/docker/metadata-action
       - name: Docker PHP meta
         id: meta_php
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ github.actor }}/linguacafe-webserver
-          tags: |
-            type=ref,event=branch
-            type=ref,suffix=-${{ env.BUILD_DATE}},event=branch
-
-      # https://github.com/docker/metadata-action
-      - name: Docker Python meta
-        id: meta_python
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ github.actor }}/linguacafe-python-service
           tags: |
             type=ref,event=branch
             type=ref,suffix=-${{ env.BUILD_DATE}},event=branch
@@ -72,6 +68,38 @@ jobs:
 
       - name: PHP Image digest
         run: echo ${{ steps.docker_build_php.outputs.digest }}
+
+  build-and-push-python-image:
+    runs-on: ubuntu-22.04
+    needs: capture-date
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      # set up Docker build action
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      # https://github.com/docker/metadata-action
+      - name: Docker Python meta
+        id: meta_python
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.actor }}/linguacafe-python-service
+          tags: |
+            type=ref,event=branch
+            type=ref,suffix=-${{ env.BUILD_DATE}},event=branch
+
+      # https://github.com/docker/login-action#github-container-registry
+      - name: Log in to Github Packages
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_LINGUA_PAT }}
 
       # https://github.com/docker/build-push-action
       - name: Build and push Python image to GitHub Container Registry


### PR DESCRIPTION
Hi simjanos, long time no see!

This PR is made to address the slow build times for ARM64 and to fix the various warning in the CI.

On my testing, the first build was done in the amount of time you are used to, 20 minutes for PHP ARM64 image, but the second build used the cached layers and was done in just 2 minutes 40 seconds.

I have not reinstated the Python ARM64, that's up to you for when you decide to enable back.

I have also noticed you have been using pre-releases to signal that a beta was out, please let me know if you want me to change this action from manual to be triggered on a pre-release instead.

Cheers.