### PR TITLE
fix: missing spaces in review page copy

### DIFF
--- a/resources/js/components/Review/Review.vue
+++ b/resources/js/components/Review/Review.vue
@@ -211,8 +211,8 @@
                                         <div class="phrase-words" :style="{'font-size': (settings.fontSize) + 'px'}">
                                             <span
                                                 v-for="(word, wordIndex) in exampleSentence.words" :key="wordIndex"
-                                                :class="{'selected-font': true, 'mr-2': word.spaceAfter}"
-                                            >{{ word.word }}</span>
+                                                :class="{'selected-font': true}"
+                                            >{{ word.word }}<span v-if="word.spaceAfter">&nbsp;</span></span>
                                         </div>
                                     </template>
                                 </div>


### PR DESCRIPTION
When copying text from the the review page in "Plain text" mode, the pasted text would not contain any spaces. This was due to spaces between words being rendered with margin instead of space characters.

I chose to replace the margin rendering, with non-breaking spaces (&nbsp;).


## Example
![image](https://github.com/user-attachments/assets/66a81f1f-b17b-4d15-804f-c1019b54614f)

New rendering seems find seems fine to me.