### PR TITLE
chore: add intl PHP extension to dev webserver

### DIFF
--- a/docker/PhpDockerfileDev
+++ b/docker/PhpDockerfileDev
@@ -32,6 +32,7 @@ RUN docker-php-ext-install pdo pdo_mysql fileinfo \
     && docker-php-ext-install mysqli \
     && docker-php-ext-install zip \
     && docker-php-ext-install pcntl \
+    && docker-php-ext-install intl \
     && docker-php-source delete
 
 #php config


### PR DESCRIPTION
Without the `intl` PHP extension, artisan fails when attempting to show db info i.e. `php artisan db:show`.

For example, here's the error message displayed without `intl` installed on the `webserver` host.

<img width="960" height="505" alt="lc_php_intl" src="https://github.com/user-attachments/assets/3b88a0ea-1542-4c36-b818-96c33f00f56d" />
