### PR TITLE
Youtube import shortlinks

### DIFF
--- a/python_microservice/server.py
+++ b/python_microservice/server.py
@@ -5,6 +5,7 @@ import os
 import json
 from urllib import parse
 from newspaper import Article
+from youtube_transcript_api import IpBlocked, RequestBlocked
 
 from services import PackageManagerService
 from services import YoutubeService
@@ -106,9 +107,19 @@ def getYoutubeSubtitleList():
 
     url = request.json.get('url')
     parsedUrl = parse.urlparse(url)
-    videoId = parse.parse_qs(parsedUrl.query)['v'][0]
 
-    return json.dumps(youtubeService.getYoutubeSubtitleList(videoId))
+    if parsedUrl.netloc == 'www.youtube.com': # parse regular Youtube links
+        videoId = parse.parse_qs(parsedUrl.query)['v'][0]
+    elif parsedUrl.netloc == 'www.youtu.be': # parse Youtube shortlinks
+        videoId = parsedUrl.path[1:]
+    else:
+        raise ValueError("A valid Youtube URL must be provided to retrieve a subtitle list.")
+
+    try:
+        subtitles = youtubeService.getYoutubeSubtitleList(videoId)
+        return json.dumps(subtitles)
+    except (IpBlocked, RequestBlocked):
+        return HTTPResponse(status=419, body='Error: your IP may have been blocked by Youtube.')
 
 
 @route('/subtitles/read', method='POST')

--- a/python_microservice/server.py
+++ b/python_microservice/server.py
@@ -108,9 +108,9 @@ def getYoutubeSubtitleList():
     url = request.json.get('url')
     parsedUrl = parse.urlparse(url)
 
-    if parsedUrl.netloc == 'www.youtube.com': # parse regular Youtube links
+    if parsedUrl.netloc in ['www.youtube.com', 'm.youtube.com']: # parse regular Youtube links
         videoId = parse.parse_qs(parsedUrl.query)['v'][0]
-    elif parsedUrl.netloc == 'www.youtu.be' or parsedUrl.netloc == 'youtu.be': # parse Youtube shortlinks
+    elif parsedUrl.netloc in  ['www.youtu.be', 'youtu.be']: # parse Youtube shortlinks
         videoId = parsedUrl.path[1:]
     else:
         raise ValueError("A valid Youtube URL must be provided to retrieve a subtitle list.")

--- a/python_microservice/server.py
+++ b/python_microservice/server.py
@@ -110,7 +110,7 @@ def getYoutubeSubtitleList():
 
     if parsedUrl.netloc == 'www.youtube.com': # parse regular Youtube links
         videoId = parse.parse_qs(parsedUrl.query)['v'][0]
-    elif parsedUrl.netloc == 'www.youtu.be': # parse Youtube shortlinks
+    elif parsedUrl.netloc == 'www.youtu.be' or parsedUrl.netloc == 'youtu.be': # parse Youtube shortlinks
         videoId = parsedUrl.path[1:]
     else:
         raise ValueError("A valid Youtube URL must be provided to retrieve a subtitle list.")


### PR DESCRIPTION
Pretty short and sweet. This just adds a check to accept Youtube short links (e.g. https://youtu.be/aPhCaDI4Dq0 or https://www.youtu.be/aPhCaDI4Dq0) for subtitle imports.

Note, I haven't included it in this PR, but it may be a good idea to document somewhere how errors should be handled from the Python service such that more useful error message can be supplied to the user. As of now most of the endpoints will just popup a generic error message if a request fails.

For example, when Youtube has blocked a user's IP, they'll get a generic message like this even if they've supplied a valid URL.
<img width="969" height="342" alt="image" src="https://github.com/user-attachments/assets/961bf5ac-fd21-4cb9-9468-27bc1f3ff1b5" />
