### PR TITLE
Epub import preserve blocks option

### DIFF
--- a/app/Enums/Import/EbookTextProcessingMethodEnum.php
+++ b/app/Enums/Import/EbookTextProcessingMethodEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums\Import;
+
+enum EbookTextProcessingMethodEnum: string
+{
+    case PLAINTEXT = 'plaintext';
+    case PRESERVE_BLOCK_TAGS = 'preserve_block_tags';
+}

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Enums\Import\EbookChapterSortMethodEnum;
+use App\Enums\Import\EBookTextProcessingMethodEnum;
 use App\Enums\Import\ImportTypeEnum;
 use App\Helpers\Language\LanguageConfig;
 use App\Http\Requests\Import\ImportRequest;
@@ -25,6 +26,7 @@ class ImportController extends Controller
         $book = Book::find($request->validated('bookId'));
         $importType = ImportTypeEnum::from($request->validated('importType'));
         $eBookChapterSortMethod = EbookChapterSortMethodEnum::from($request->validated('eBookChapterSortMethod'));
+        $eBookTextProcessingMethod = EbookTextProcessingMethodEnum::from($request->validated('textProcessingMethod'));
         $bookName = $request->validated('bookName');
         $chapterName = $request->validated('chapterName');
         $chunkSize = intval($request->validated('maximumCharactersPerChapter'));
@@ -38,6 +40,7 @@ class ImportController extends Controller
             language: $language,
             chunkSize: $chunkSize,
             eBookChapterSortMethod: $eBookChapterSortMethod,
+            eBookTextProcessingMethod: $eBookTextProcessingMethod,
             chapterName: $chapterName,
             book: $book ?? null,
             bookName: $bookName ?? null,

--- a/app/Http/Requests/Import/ImportRequest.php
+++ b/app/Http/Requests/Import/ImportRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Import;
 
 use App\Enums\Import\EbookChapterSortMethodEnum;
+use App\Enums\Import\EbookTextProcessingMethodEnum;
 use App\Enums\Import\ImportTypeEnum;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -34,6 +35,10 @@ class ImportRequest extends FormRequest
             'eBookChapterSortMethod' => [
                 'required',
                 Rule::enum(EbookChapterSortMethodEnum::class),
+            ],
+            'textProcessingMethod' => [
+                'required',
+                Rule::enum(EbookTextProcessingMethodEnum::class),
             ],
             'bookId' => [
                 'required',

--- a/app/Services/ImportService.php
+++ b/app/Services/ImportService.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Enums\ChapterProcessingStatusEnum;
 use App\Enums\Import\EbookChapterSortMethodEnum;
+use App\Enums\Import\EbookTextProcessingMethodEnum;
 use App\Enums\Import\ImportTypeEnum;
 use App\Enums\Import\TokenizerRequestTypeEnum;
 use App\Helpers\Language\LanguageConfig;
@@ -32,6 +33,7 @@ class ImportService
         LanguageConfig $language,
         int $chunkSize,
         EbookChapterSortMethodEnum $eBookChapterSortMethod,
+        EbookTextProcessingMethodEnum $eBookTextProcessingMethod,
         string $chapterName,
         ?Book $book,
         ?string $bookName,
@@ -53,6 +55,7 @@ class ImportService
                 $language,
                 $chunkSize,
                 $eBookChapterSortMethod,
+                $eBookTextProcessingMethod,
                 $this->getFullTempFilePath($fileName),
                 $importText ?? null,
                 $importSubtitles ?? null
@@ -100,6 +103,7 @@ class ImportService
         LanguageConfig $language,
         int $chunkSize,
         EbookChapterSortMethodEnum $eBookChapterSortMethod,
+        EBookTextProcessingMethodEnum $eBookTextProcessingMethod,
         ?string $fileName,
         ?string $importText,
         ?string $importSubtitles,
@@ -113,6 +117,7 @@ class ImportService
         $requestTypeBasedImportData = match ($tokenizerRequestType) {
             TokenizerRequestTypeEnum::E_BOOK => [
                 'chapterSortMethod' => $eBookChapterSortMethod->value,
+                'textProcessingMethod' => $eBookTextProcessingMethod->value,
                 'importFile' => $fileName,
             ],
             TokenizerRequestTypeEnum::SUBTITLE => [

--- a/docker/PythonDockerfile
+++ b/docker/PythonDockerfile
@@ -19,6 +19,7 @@ RUN pip install -U --no-cache-dir \
         wheel \
         lxml \
         lxml_html_clean \
+        html5lib \
 #youtube api
         youtube_transcript_api \
 #ebook library

--- a/docker/PythonDockerfileDev
+++ b/docker/PythonDockerfileDev
@@ -21,6 +21,7 @@ RUN pip install -U --no-cache-dir \
         wheel \
         lxml \
         lxml_html_clean \
+        html5lib \
 #youtube api
         youtube_transcript_api \
 #ebook library

--- a/python_microservice/server.py
+++ b/python_microservice/server.py
@@ -77,8 +77,11 @@ def loadEbookIntoChunks():
     importFile = request.json.get('importFile')
     language = transformLanguage(request.json.get('language'))
     chunkSize = request.json.get('chunkSize')
-    textProcessingMethod = request.json.get('textProcessingMethod')
     chapterSortMethod = request.json.get('chapterSortMethod')
+    try:
+        textProcessingMethod = EbookService.TextProcessingMethod[request.json.get('textProcessingMethod')]
+    except KeyError:
+        textProcessingMethod = EbookService.TextProcessingMethod.plaintext
 
     bookTextChunks = ebookService.loadEbookIntoChunks(
         importFile, language, chunkSize, textProcessingMethod, chapterSortMethod

--- a/python_microservice/services/EbookService.py
+++ b/python_microservice/services/EbookService.py
@@ -1,18 +1,25 @@
 import lxml_html_clean
 import lxml.html
+from lxml.html import html5parser
 from ebooklib import epub
 import ebooklib
 import re
+from enum import Enum, auto
+
 from . import TokenizerConfig
 
 config = TokenizerConfig.TokenizerConfig()
 
 
+class TextProcessingMethod(Enum):
+    plaintext = auto()
+    preserve_block_tags = auto()
+
 class EbookService:
     def loadEbookIntoChunks(
-        self, importFile, language, chunkSize, textProcessingMethod, chapterSortMethod
+        self, importFile, language, chunkSize, textProcessingMethod: TextProcessingMethod, chapterSortMethod
     ):
-        content = self.loadEbookFile(importFile, chapterSortMethod)
+        content = self.loadEbookFile(importFile, chapterSortMethod, textProcessingMethod)
         content = content.replace('\r\n', ' NEWLINE ')
         content = content.replace('\n', ' NEWLINE ')
 
@@ -31,16 +38,50 @@ class EbookService:
             chunks[-1] = chunks[-1].replace(' NEWLINE ', '\r\n')
             chunks[-1] = chunks[-1].replace('\xa0', ' ')
 
+
         return chunks
 
-    def loadEbookFile(self, file, sortMethod):
+    def processPage(self, page: str, textProcessingMethod: TextProcessingMethod) -> str:
+        content = ''
+        match textProcessingMethod:
+            case TextProcessingMethod.plaintext:
+                # needed to removed extra div created by cleaner...
+                page = lxml.html.fromstring(page).text_content()
+                content += page
+            case TextProcessingMethod.preserve_block_tags:
+                content = ''
+                block_tags = [
+                    'p',
+                    r'{http://www.w3.org/1999/xhtml}p',
+                    'div',
+                    r'{http://www.w3.org/1999/xhtml}div',
+                    'img',
+                    r'{http://www.w3.org/1999/xhtml}img',
+                ]
+                element = html5parser.fromstring(page)
+                for sub_element in element.iter():
+                    # add leading linebreak text from block tags for readability
+                    if sub_element.tag in block_tags:
+                        content += "\n\n"
+
+                    # concat text before the first subelement
+                    if leading_text := sub_element.text:
+                        content += leading_text
+
+                    # concat text after an element's end tag, but before the next sibling's start tag
+                    if (tail_text := sub_element.tail):
+                        # In the case that the tail_text contains whitespace between inline (non-block) tags
+                        # the tail_text should not be included
+                        if not tail_text.isspace():
+                            content += tail_text
+
+        return content
+
+                
+
+
+    def loadEbookFile(self, file, sortMethod, textProcessingMethod: TextProcessingMethod):
         # rp and rt tags are used in adding prononciation over words, we need to remove the content of the tags
-        cleaner = lxml_html_clean.Cleaner(
-            allow_tags=[''],
-            remove_unknown_tags=False,
-            kill_tags=['rp', 'rt'],
-            page_structure=False,
-        )
 
         content = ''
         book = epub.read_epub(file)
@@ -61,10 +102,13 @@ class EbookService:
                 # and then use RegEx to remove the encoding declaration
                 content_str = item.get_content().decode()
                 content_str = re.sub(r'<\?xml[^>]+\?>', '', content_str, count=1)
+                cleaner = lxml_html_clean.Cleaner(
+                    allow_tags=[],
+                    remove_unknown_tags=False,
+                    kill_tags=['rp', 'rt'],
+                    page_structure=False,
+                )
                 epubPage = cleaner.clean_html(content_str)
+                content += self.processPage(epubPage, textProcessingMethod)
 
-                # needed to removed extra div created by cleaner...
-                epubPage = lxml.html.fromstring(epubPage).text_content()
-                content += epubPage
-
-        return str(content)
+        return content

--- a/resources/js/components/Home/PatchNotes.vue
+++ b/resources/js/components/Home/PatchNotes.vue
@@ -22,6 +22,7 @@
                     <li>Added context to custom API dictionary requests.</li>
                     <li>Added continue reading feature.</li>
                     <li>Added support for more subtitle formats.</li>
+                    <li>Added support for preserving white spaces in imported e-books.</li>
                 </ul>
 
                 <b>Bug fixes:</b>

--- a/resources/js/components/Library/Import/ImportOptions.vue
+++ b/resources/js/components/Library/Import/ImportOptions.vue
@@ -36,6 +36,43 @@
                 </v-radio>
             </v-radio-group>
 
+            <!-- E-book processing method -->
+            <label class="font-weight-bold mt-2" v-if="$props.type === 'e-book'">
+                E-book processing method
+                <v-menu offset-y nudge-top="-12px">
+                    <template v-slot:activator="{ on, attrs }">
+                        <v-icon class="ml-1" v-bind="attrs" v-on="on"
+                            >mdi-help-circle-outline</v-icon
+                        >
+                    </template>
+                    <v-card outlined class="rounded-lg pa-4" width="320px">
+                        In some cases, processing with the "Plaintext" option may result in
+                        erroneous word tokenization. The "Preserve blocks" option inserts breaks
+                        between paragraphs and other block elements from the original ebook format
+                        to prevent these errors and to improve readability in some cases, though it
+                        may be slightly slower.
+                    </v-card>
+                </v-menu>
+            </label>
+
+            <v-radio-group
+                v-if="$props.type === 'e-book'"
+                v-model="textProcessingMethod"
+                @change="importOptionsChanged"
+                class="mt-0"
+            >
+                <v-radio value="plaintext">
+                    <template v-slot:label>
+                        <div>Plaintext</div>
+                    </template>
+                </v-radio>
+                <v-radio value="preserve_block_tags">
+                    <template v-slot:label>
+                        <div>Preserve blocks</div>
+                    </template>
+                </v-radio>
+            </v-radio-group>
+
             <!-- Text processing method label -->
             <label class="font-weight-bold mt-2">Maximum characters per chapter</label>
             <v-text-field
@@ -71,6 +108,7 @@ export default {
     data: function () {
         return {
             eBookChapterSortMethod: 'default',
+            textProcessingMethod: 'plaintext',
             isFormValid: false,
             maximumCharactersPerChapter:
                 this.$props.language == 'chinese' || this.$props.language == 'japanese'
@@ -110,6 +148,7 @@ export default {
             this.$emit('import-options-changed', {
                 maximumCharactersPerChapter: this.maximumCharactersPerChapter,
                 eBookChapterSortMethod: this.eBookChapterSortMethod,
+                textProcessingMethod: this.textProcessingMethod,
                 isValid: valid,
             })
         },


### PR DESCRIPTION
- Adds a radio button input to select two different text processing methods for EPUB imports
    1. Plaintext: original default method which simply extracts all text without regard for existing space between elements
    2. Preserve blocks: inserts newlines between common block tags to improve readability but also prevent some tokenization errors
- Partially resolves issue #415. There may still be instances of improper tokenization, but this option reduces them with the "Preserve blocks" import option by eliminating any cases that occur due to text from block tags being joined together without any spaces.

Resolves issue #455