### PR TITLE
Add word form selector dropdown to dictionary search field

### DIFF
--- a/frontend/vue2/js/components/Text/VocabularyBottomSheet.vue
+++ b/frontend/vue2/js/components/Text/VocabularyBottomSheet.vue
@@ -141,7 +141,25 @@
                         :value="searchField"
                         @change="searchFieldChanged"
                         @keydown.stop=""
-                    ></v-text-field>
+                    >
+                        <template v-slot:append v-if="word && lemma && word !== lemma">
+                            <v-menu offset-y left v-model="formMenuOpen" :close-on-click="false">
+                                <template v-slot:activator="{ on, attrs }">
+                                    <v-btn icon x-small v-bind="attrs" v-on="on" title="Select word form" @mouseup.stop="">
+                                        <v-icon small>mdi-chevron-down</v-icon>
+                                    </v-btn>
+                                </template>
+                                <v-list dense>
+                                    <v-list-item @click.stop="selectForm(lemma, 'lemma')" @mouseup.stop="">
+                                        <v-list-item-title>{{ lemma }} <span class="grey--text text-caption">(lemma)</span></v-list-item-title>
+                                    </v-list-item>
+                                    <v-list-item @click.stop="selectForm(word, 'exact')" @mouseup.stop="">
+                                        <v-list-item-title>{{ word }} <span class="grey--text text-caption">(exact)</span></v-list-item-title>
+                                    </v-list-item>
+                                </v-list>
+                            </v-menu>
+                        </template>
+                    </v-text-field>
                 </v-tab-item>
 
                 <v-tab-item :value="1"></v-tab-item>
@@ -314,6 +332,7 @@ export default {
             // ui data
             tab: 0,
             searchField: '',
+            formMenuOpen: false,
             searchResults: [],
         }
     },
@@ -366,10 +385,19 @@ export default {
             this.lemmaReading = this._lemmaReading
             this.phraseReading = this._phraseReading
             this.searchField = this._searchField
+            if (localStorage.getItem('linguacafe_search_form_preference') === 'exact' && this.word && this.word !== this._searchField) {
+                this.searchField = this.word
+            }
             this.exampleSentenceText = this._exampleSentenceText
         },
         textToSpeech() {
             this.$emit('textToSpeech')
+        },
+        selectForm(value, type) {
+            localStorage.setItem('linguacafe_search_form_preference', type)
+            this.formMenuOpen = false
+            this.searchField = value
+            this.searchFieldChanged(value)
         },
         searchFieldChanged(event) {
             if (event === '') {

--- a/frontend/vue2/js/components/Text/VocabularyBox.vue
+++ b/frontend/vue2/js/components/Text/VocabularyBox.vue
@@ -212,7 +212,25 @@
                             :value="searchField"
                             @change="searchFieldChanged"
                             @keydown.stop=""
-                        ></v-text-field>
+                        >
+                            <template v-slot:append v-if="word && lemma && word !== lemma">
+                                <v-menu offset-y left v-model="formMenuOpen" :close-on-click="false">
+                                    <template v-slot:activator="{ on, attrs }">
+                                        <v-btn icon x-small v-bind="attrs" v-on="on" title="Select word form" @mouseup.stop="">
+                                            <v-icon small>mdi-chevron-down</v-icon>
+                                        </v-btn>
+                                    </template>
+                                    <v-list dense>
+                                        <v-list-item @click.stop="selectForm(lemma, 'lemma')" @mouseup.stop="">
+                                            <v-list-item-title>{{ lemma }} <span class="grey--text text-caption">(lemma)</span></v-list-item-title>
+                                        </v-list-item>
+                                        <v-list-item @click.stop="selectForm(word, 'exact')" @mouseup.stop="">
+                                            <v-list-item-title>{{ word }} <span class="grey--text text-caption">(exact)</span></v-list-item-title>
+                                        </v-list-item>
+                                    </v-list>
+                                </v-menu>
+                            </template>
+                        </v-text-field>
 
                         <!-- Search box -->
                         <vocabulary-search-box
@@ -486,6 +504,7 @@ export default {
             // ui data
             tab: 0,
             searchField: '',
+            formMenuOpen: false,
             searchResults: [],
             showWordImageEditBoxDialog: false,
         }
@@ -504,10 +523,19 @@ export default {
             this.lemmaReading = this._lemmaReading
             this.phraseReading = this._phraseReading
             this.searchField = this._searchField
+            if (localStorage.getItem('linguacafe_search_form_preference') === 'exact' && this.word && this.word !== this._searchField) {
+                this.searchField = this.word
+            }
             this.exampleSentenceText = this._exampleSentenceText
         },
         textToSpeech() {
             this.$emit('textToSpeech')
+        },
+        selectForm(value, type) {
+            localStorage.setItem('linguacafe_search_form_preference', type)
+            this.formMenuOpen = false
+            this.searchField = value
+            this.searchFieldChanged(value)
         },
         searchFieldChanged(event) {
             if (event === '') {

--- a/frontend/vue2/js/components/Text/VocabularySideBox.vue
+++ b/frontend/vue2/js/components/Text/VocabularySideBox.vue
@@ -293,7 +293,25 @@
                     :value="searchField"
                     @change="searchFieldChanged"
                     @keydown.stop=""
-                ></v-text-field>
+                >
+                    <template v-slot:append v-if="word && lemma && word !== lemma">
+                        <v-menu offset-y left v-model="formMenuOpen" :close-on-click="false">
+                            <template v-slot:activator="{ on, attrs }">
+                                <v-btn icon x-small v-bind="attrs" v-on="on" title="Select word form" @mouseup.stop="">
+                                    <v-icon small>mdi-chevron-down</v-icon>
+                                </v-btn>
+                            </template>
+                            <v-list dense>
+                                <v-list-item @click.stop="selectForm(lemma, 'lemma')" @mouseup.stop="">
+                                    <v-list-item-title>{{ lemma }} <span class="grey--text text-caption">(lemma)</span></v-list-item-title>
+                                </v-list-item>
+                                <v-list-item @click.stop="selectForm(word, 'exact')" @mouseup.stop="">
+                                    <v-list-item-title>{{ word }} <span class="grey--text text-caption">(exact)</span></v-list-item-title>
+                                </v-list-item>
+                            </v-list>
+                        </v-menu>
+                    </template>
+                </v-text-field>
 
                 <!-- Search box -->
                 <vocabulary-search-box
@@ -421,6 +439,7 @@ export default {
             // ui data
             tab: 0,
             searchField: '',
+            formMenuOpen: false,
             searchResults: [],
         }
     },
@@ -440,6 +459,9 @@ export default {
             this.lemmaReading = this._lemmaReading
             this.phraseReading = this._phraseReading
             this.searchField = this._searchField
+            if (localStorage.getItem('linguacafe_search_form_preference') === 'exact' && this.word && this.word !== this._searchField) {
+                this.searchField = this.word
+            }
             this.exampleSentenceText = this._exampleSentenceText
 
             // generate phrase text
@@ -461,6 +483,12 @@ export default {
         },
         textToSpeech() {
             this.$emit('textToSpeech')
+        },
+        selectForm(value, type) {
+            localStorage.setItem('linguacafe_search_form_preference', type)
+            this.formMenuOpen = false
+            this.searchField = value
+            this.searchFieldChanged(value)
         },
         searchFieldChanged(event) {
             if (event === '') {


### PR DESCRIPTION
As discussed in Discord.
When clicking on a conjugated word, the dictionary search defaults to the lemma. For heavily inflected languages like Russian this is often unhelpful, e.g. clicking "беги" searches for "бежать". This adds a small dropdown chevron inside the dictionary search field that lets the user choose between the lemma and the exact clicked form. The last choice is remembered in localStorage.
<img width="1367" height="1169" alt="image" src="https://github.com/user-attachments/assets/170a7838-f14c-4590-8a6c-a0f4fc30f5ac" />
